### PR TITLE
Feature/curie annotation

### DIFF
--- a/src/main/java/io/openapitools/jackson/dataformat/hal/annotation/Curie.java
+++ b/src/main/java/io/openapitools/jackson/dataformat/hal/annotation/Curie.java
@@ -1,0 +1,26 @@
+package io.openapitools.jackson.dataformat.hal.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Annotation specifying a CURIE for use with links
+ */
+@Target({ElementType.TYPE })
+@Retention(RetentionPolicy.RUNTIME)
+public @interface Curie {
+
+    /**
+     * CURIE href template e.g. "http://docs.my.site/{rel}"
+     */
+    String href() default "";
+
+    /**
+     * CURIE name used to reference the CURIE in {@link Link} annotations
+     * e.g. "mysite"
+     */
+    String curie() default "";
+
+}

--- a/src/main/java/io/openapitools/jackson/dataformat/hal/annotation/Curies.java
+++ b/src/main/java/io/openapitools/jackson/dataformat/hal/annotation/Curies.java
@@ -1,0 +1,20 @@
+package io.openapitools.jackson.dataformat.hal.annotation;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Annotation specifying a CURIE for use with links
+ */
+@Target({ElementType.TYPE })
+@Retention(RetentionPolicy.RUNTIME)
+public @interface Curies {
+
+    /**
+     * Annotation grouping a list of {@link Curies} for convenience/readability
+     */
+    Curie[] value() default {};
+
+}

--- a/src/main/java/io/openapitools/jackson/dataformat/hal/annotation/Link.java
+++ b/src/main/java/io/openapitools/jackson/dataformat/hal/annotation/Link.java
@@ -16,4 +16,10 @@ public @interface Link {
      * @return name of the relation represented by the link.
      */
     String value() default "";
+
+    /**
+     * CURIE name - if not set then no CURIE will be associated.
+     * @return name of the CURIE intended to be used with this link.
+     */
+    String curie() default "";
 }

--- a/src/main/java/io/openapitools/jackson/dataformat/hal/deser/HALBeanDeserializer.java
+++ b/src/main/java/io/openapitools/jackson/dataformat/hal/deser/HALBeanDeserializer.java
@@ -14,7 +14,7 @@ import java.util.Iterator;
 import java.util.Map;
 
 /**
- * Deserializer to handle incomming application/hal+json.
+ * Deserializer to handle incoming application/hal+json.
  */
 public class HALBeanDeserializer extends DelegatingDeserializer {
 
@@ -30,6 +30,7 @@ public class HALBeanDeserializer extends DelegatingDeserializer {
             for (ReservedProperty rp : ReservedProperty.values()) {
                 ObjectNode on = (ObjectNode) tn.get(rp.getPropertyName());
                 if (on != null) {
+                    removeCuries(rp, on);
                     Iterator<Map.Entry<String,JsonNode>> it = on.fields();
                     while (it.hasNext()) {
                         Map.Entry<String,JsonNode> jn = it.next();
@@ -44,6 +45,17 @@ public class HALBeanDeserializer extends DelegatingDeserializer {
         final JsonParser modifiedParser = tn.traverse(p.getCodec());
         modifiedParser.nextToken();
         return _delegatee.deserialize(modifiedParser, ctxt);
+    }
+
+    private void removeCuries(ReservedProperty rp, ObjectNode on) {
+        // Check for curies in the _links object.  If they exist, remove them
+        // as we have nothing in the bean to deserialize into.  Curies only exist
+        // as annotations on the bean!
+        if (rp == ReservedProperty.LINKS) {
+            if (on.has("curies")) {
+                on.remove("curies");
+            }
+        }
     }
 
     @Override

--- a/src/main/java/io/openapitools/jackson/dataformat/hal/deser/ReservedProperty.java
+++ b/src/main/java/io/openapitools/jackson/dataformat/hal/deser/ReservedProperty.java
@@ -2,6 +2,7 @@ package io.openapitools.jackson.dataformat.hal.deser;
 
 import com.fasterxml.jackson.databind.introspect.AnnotatedMember;
 import com.fasterxml.jackson.databind.introspect.BeanPropertyDefinition;
+import io.openapitools.jackson.dataformat.hal.annotation.Curies;
 import io.openapitools.jackson.dataformat.hal.annotation.EmbeddedResource;
 import io.openapitools.jackson.dataformat.hal.annotation.Link;
 
@@ -44,6 +45,13 @@ public enum ReservedProperty {
 
         Annotation o = annotatedMember.getAnnotation(annotation);
         if (o != null) {
+            // Handle the special case for curies first...
+            if (o.annotationType() == Link.class) {
+                String curie = ((Link) o).curie();
+                if (curie != null && !curie.isEmpty()) {
+                    return alternateName(curie + ":" + originalName);
+                }
+            }
             try {
                 String alternateName = (String) valueMethod.invoke(o);
                 return alternateName(alternateName.isEmpty() ? originalName : alternateName);

--- a/src/main/java/io/openapitools/jackson/dataformat/hal/ser/HALBeanSerializerModifier.java
+++ b/src/main/java/io/openapitools/jackson/dataformat/hal/ser/HALBeanSerializerModifier.java
@@ -15,7 +15,7 @@ public class HALBeanSerializerModifier extends BeanSerializerModifier {
     public JsonSerializer<?> modifySerializer(SerializationConfig config, BeanDescription beanDesc, JsonSerializer<?> serializer) {
         Resource ann = beanDesc.getClassAnnotations().get(Resource.class);
         if (ann != null) {
-            return new HALBeanSerializer((BeanSerializer) serializer);
+            return new HALBeanSerializer((BeanSerializer) serializer, beanDesc);
         }
         return serializer;
     }

--- a/src/test/java/io/openapitoools/jackson/dataformat/hal/deser/HALBeanDeserializerMethodAnnIT.java
+++ b/src/test/java/io/openapitoools/jackson/dataformat/hal/deser/HALBeanDeserializerMethodAnnIT.java
@@ -4,6 +4,7 @@ package io.openapitoools.jackson.dataformat.hal.deser;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import io.openapitools.jackson.dataformat.hal.HALLink;
 import io.openapitools.jackson.dataformat.hal.HALMapper;
+import io.openapitools.jackson.dataformat.hal.annotation.Curie;
 import io.openapitools.jackson.dataformat.hal.annotation.EmbeddedResource;
 import io.openapitools.jackson.dataformat.hal.annotation.Link;
 import io.openapitools.jackson.dataformat.hal.annotation.Resource;
@@ -27,12 +28,21 @@ public class HALBeanDeserializerMethodAnnIT {
         final String json = "{" +
                 "  \"name\": \"POJO name\"," +
                 "  \"_links\": {" +
+                "    \"curies\": [{" +
+                "      \"href\": \"http://my.example.com/doc/{rel}\"," +
+                "      \"name\": \"cur1\"," +
+                "      \"templated\": true" +
+                "    }]," +
                 "    \"self\": {" +
                 "      \"href\": \"http://self.url\"," +
                 "      \"templated\": false" +
                 "    }," +
                 "    \"link1\": {" +
                 "      \"href\": \"http://other.link.url\"," +
+                "      \"templated\": true" +
+                "    }," +
+                "    \"cur1:link2\": {" +
+                "      \"href\": \"http://link2.url\"," +
                 "      \"templated\": true" +
                 "    }" +
                 "  }," +
@@ -56,6 +66,7 @@ public class HALBeanDeserializerMethodAnnIT {
     }
 
 
+    @Curie(curie = "cur1", href = "http://my.example.com/doc/{rel}")
     @Resource
     public static class TestResource {
         // Guard against Jackson unintentionally using class fields for deserialization.
@@ -73,6 +84,11 @@ public class HALBeanDeserializerMethodAnnIT {
         @Link("link1")
         public void setOtherlink(HALLink link) {
             fields.put("otherlink", link);
+        }
+
+        @Link(value = "link2", curie = "cur1")
+        public void setLink2(HALLink link) {
+            fields.put("http://link2.url", link);
         }
 
         @EmbeddedResource("extras")

--- a/src/test/java/io/openapitoools/jackson/dataformat/hal/ser/HALBeanSerializerMethodAnnIT.java
+++ b/src/test/java/io/openapitoools/jackson/dataformat/hal/ser/HALBeanSerializerMethodAnnIT.java
@@ -42,8 +42,6 @@ public class HALBeanSerializerMethodAnnIT {
         assertFalse(links.isMissingNode());
         assertEquals(4, links.size());
 
-        System.out.println(links);
-
         JsonNode relative1UsingCurie = links.get("cur1:relative2");
         assertFalse(relative1UsingCurie.isMissingNode());
 


### PR DESCRIPTION
Second attempt for some initial feedback.  Only submitted to keep the discussion going.  Likely needs documentation and more test coverage etc.  Just scratched out the general shape for collective musing on whether or not this is going in the right direction.  Will improve if it's looking somewhat sensible.

For serialization:

I supported either a single Curie annotation by itself or multiple wrapped in a Curies annotation.  Potential to simplify if I remove the single Curie support and just force usage always with the Curies wrapper annotation.

For deserialization:

Yowzers! I feel like my attempt here was ham-fisted at best and an outright hack at worst.  Could definitely do with closer inspection from anyone knowledgeable in this area.  

The general philosophy is that the Curies have nothing to be deserialized into as they live purely as annotations on the bean.  Hence I just throw them out of the JSON as fast as possible.  

Many thanks in advance for any help and guidance here!