### PR TITLE
Fix serialization of beans that are annotated with @JsonTypeInfo()

### DIFF
--- a/src/test/java/io/openapitoools/jackson/dataformat/hal/ser/HALBeanSerializerPolymorphicIT.java
+++ b/src/test/java/io/openapitoools/jackson/dataformat/hal/ser/HALBeanSerializerPolymorphicIT.java
@@ -1,0 +1,151 @@
+package io.openapitoools.jackson.dataformat.hal.ser;
+
+import static org.junit.Assert.assertEquals;
+
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.annotation.JsonTypeInfo.As;
+import com.fasterxml.jackson.annotation.JsonTypeInfo.Id;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.openapitools.jackson.dataformat.hal.HALLink;
+import io.openapitools.jackson.dataformat.hal.HALMapper;
+import io.openapitools.jackson.dataformat.hal.annotation.EmbeddedResource;
+import io.openapitools.jackson.dataformat.hal.annotation.Link;
+import io.openapitools.jackson.dataformat.hal.annotation.Resource;
+import java.net.URI;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+import org.junit.Test;
+
+public class HALBeanSerializerPolymorphicIT {
+
+  ObjectMapper om = new HALMapper();
+
+  @Test
+  public void testSerializationForResourceWithEmbeddableList() throws Exception {
+    TopResource resource = new TopResource();
+    String json = om.writeValueAsString(resource);
+    assertEquals(
+        "{"
+            + "\"_links\":{"
+            + "\"child\":[{\"href\":\"/top/1/child/1\"},{\"href\":\"/top/1/child/2\"}],"
+            + "\"self\":{\"href\":\"/top/1\"}"
+            + "},"
+            + "\"_embedded\":{"
+            + "\"child\":["
+            + "{\"_links\":{\"self\":{\"href\":\"/top/1/child/1\"}},\"type\":\"ChildResource\",\"id\":\"1\"},"
+            + "{\"_links\":{\"self\":{\"href\":\"/top/1/child/2\"}},\"type\":\"OtherChildResource\",\"id\":\"2\",\"name\":\"Max\"}]"
+            + "},"
+            + "\"id\":\"1\"}",
+        json);
+  }
+
+  @Test
+  public void testSerializationForResourceWithList() throws Exception {
+    TopResourceWithoutEmbedded resource = new TopResourceWithoutEmbedded();
+    String json = om.writeValueAsString(resource);
+    assertEquals(
+        "{"
+            + "\"_links\":{"
+            + "\"self\":{\"href\":\"/top/1\"}"
+            + "},"
+            + "\"id\":\"1\","
+            + "\"children\":["
+            + "{\"_links\":{\"self\":{\"href\":\"/top/1/child/1\"}},\"type\":\"ChildResource\",\"id\":\"1\"},"
+            + "{\"_links\":{\"self\":{\"href\":\"/top/1/child/2\"}},\"type\":\"OtherChildResource\",\"id\":\"2\",\"name\":\"Max\"}]"
+            + "}",
+        json);
+  }
+
+  @Test
+  public void testSerializationForAnnotatedPolymorphicObject() throws Exception {
+    ChildResource resource = new ChildResource("1");
+    String json = om.writeValueAsString(resource);
+    assertEquals(
+        "{"
+            + "\"_links\":{"
+            + "\"self\":{\"href\":\"/top/1/child/1\"}"
+            + "},"
+            + "\"type\":\"ChildResource\","
+            + "\"id\":\"1\"}",
+        json);
+  }
+
+  @Test
+  public void testSerializationForNotAnnotatedPolymorphicObject() throws Exception {
+    ChildResource resource = new OtherChildResource("1", "Max");
+    String json = om.writeValueAsString(resource);
+    assertEquals(
+        "{"
+            + "\"_links\":{"
+            + "\"self\":{\"href\":\"/top/1/child/1\"}"
+            + "},"
+            + "\"type\":\"ChildResource\","
+            + "\"id\":\"1\","
+            + "\"name\";\"Max\"}",
+        json);
+  }
+
+  @Resource
+  public static class TopResource {
+
+    public String id = "1";
+
+    @Link public HALLink self = new HALLink.Builder(URI.create("/top/1")).build();
+
+    @Link("child")
+    public List<HALLink> childResourcesLink =
+        Arrays.asList(
+            new HALLink.Builder(URI.create("/top/1/child/1")).build(),
+            new HALLink.Builder(URI.create("/top/1/child/2")).build());
+
+    @EmbeddedResource("child")
+    public Collection<ChildResource> children =
+        Arrays.asList(new ChildResource("1"), new OtherChildResource("2", "Max"));
+  }
+
+  @Resource
+  public static class TopResourceWithoutEmbedded {
+    public String id = "1";
+
+    @Link public HALLink self = new HALLink.Builder(URI.create("/top/1")).build();
+
+    public Collection<ChildResource> children =
+        Arrays.asList(new ChildResource("1"), new OtherChildResource("2", "Max"));
+  }
+
+  @JsonTypeInfo(
+      use = Id.NAME,
+      include = As.EXISTING_PROPERTY,
+      property = "type",
+      defaultImpl = ChildResource.class)
+  @JsonSubTypes({@JsonSubTypes.Type(value = OtherChildResource.class, name = "OtherChildResource")})
+  @Resource
+  public static class ChildResource {
+
+    public String type = "ChildResource";
+
+    public String id;
+
+    @Link public HALLink self;
+
+    public ChildResource(String id) {
+      this.id = id;
+      self = new HALLink.Builder(URI.create("/top/1/child/" + id)).build();
+    }
+  }
+
+  @Resource
+  public static class OtherChildResource extends ChildResource {
+
+    public String type = "OtherChildResource";
+
+    public String name;
+
+    public OtherChildResource(String id, String name) {
+      super(id);
+      this.name = name;
+    }
+  }
+}

--- a/src/test/java/io/openapitoools/jackson/dataformat/hal/ser/HALBeanSerializerPolymorphicWithExistingFieldIT.java
+++ b/src/test/java/io/openapitoools/jackson/dataformat/hal/ser/HALBeanSerializerPolymorphicWithExistingFieldIT.java
@@ -18,12 +18,30 @@ import java.util.Collection;
 import java.util.List;
 import org.junit.Test;
 
-public class HALBeanSerializerPolymorphicIT {
+public class HALBeanSerializerPolymorphicWithExistingFieldIT {
 
   ObjectMapper om = new HALMapper();
 
   @Test
   public void testSerializationForResourceWithEmbeddableList() throws Exception {
+    @Resource
+    class TopResource {
+
+      public String id = "1";
+
+      @Link public HALLink self = new HALLink.Builder(URI.create("/top/1")).build();
+
+      @Link("child")
+      public List<HALLink> childResourcesLink =
+          Arrays.asList(
+              new HALLink.Builder(URI.create("/top/1/child/1")).build(),
+              new HALLink.Builder(URI.create("/top/1/child/2")).build());
+
+      @EmbeddedResource("child")
+      public Collection<ChildResource> children =
+          Arrays.asList(new ChildResource("1"), new OtherChildResource("2", "Max"));
+    }
+
     TopResource resource = new TopResource();
     String json = om.writeValueAsString(resource);
     assertEquals(
@@ -43,6 +61,16 @@ public class HALBeanSerializerPolymorphicIT {
 
   @Test
   public void testSerializationForResourceWithList() throws Exception {
+    @Resource
+    class TopResourceWithoutEmbedded {
+      public String id = "1";
+
+      @Link public HALLink self = new HALLink.Builder(URI.create("/top/1")).build();
+
+      public Collection<ChildResource> children =
+          Arrays.asList(new ChildResource("1"), new OtherChildResource("2", "Max"));
+    }
+
     TopResourceWithoutEmbedded resource = new TopResourceWithoutEmbedded();
     String json = om.writeValueAsString(resource);
     assertEquals(
@@ -55,6 +83,56 @@ public class HALBeanSerializerPolymorphicIT {
             + "{\"_links\":{\"self\":{\"href\":\"/top/1/child/1\"}},\"type\":\"ChildResource\",\"id\":\"1\"},"
             + "{\"_links\":{\"self\":{\"href\":\"/top/1/child/2\"}},\"type\":\"OtherChildResource\",\"id\":\"2\",\"name\":\"Max\"}]"
             + "}",
+        json);
+  }
+
+  @Test
+  public void testSerializationForResourceEmbedded() throws Exception {
+    @Resource
+    class SimpleTopResourceEmbedded {
+      public String id = "1";
+
+      @Link public HALLink self = new HALLink.Builder(URI.create("/top/1")).build();
+
+      @EmbeddedResource public ChildResource child = new ChildResource("1");
+    }
+
+    SimpleTopResourceEmbedded resource = new SimpleTopResourceEmbedded();
+    String json = om.writeValueAsString(resource);
+    assertEquals(
+        "{"
+            + "\"_links\":{"
+            + "\"self\":{\"href\":\"/top/1\"}"
+            + "},"
+            + "\"_embedded\":{"
+            + "\"child\":{\"_links\":{\"self\":{\"href\":\"/top/1/child/1\"}},\"type\":\"ChildResource\",\"id\":\"1\"}"
+            + "},"
+            + "\"id\":\"1\"}",
+        json);
+  }
+
+  @Test
+  public void testSerializationForResource() throws Exception {
+    @Resource
+    class SimpleTopResource {
+      public String id = "1";
+
+      @Link public HALLink self = new HALLink.Builder(URI.create("/top/1")).build();
+
+      public ChildResource child = new ChildResource("1");
+    }
+
+    SimpleTopResource resource = new SimpleTopResource();
+    String json = om.writeValueAsString(resource);
+    assertEquals(
+        "{"
+            + "\"_links\":{"
+            + "\"self\":{\"href\":\"/top/1\"}"
+            + "},"
+            + "\"id\":\"1\","
+            + "\"child\":{"
+            + "\"_links\":{\"self\":{\"href\":\"/top/1/child/1\"}},\"type\":\"ChildResource\",\"id\":\"1\""
+            + "}}",
         json);
   }
 
@@ -81,38 +159,10 @@ public class HALBeanSerializerPolymorphicIT {
             + "\"_links\":{"
             + "\"self\":{\"href\":\"/top/1/child/1\"}"
             + "},"
-            + "\"type\":\"ChildResource\","
+            + "\"type\":\"OtherChildResource\","
             + "\"id\":\"1\","
-            + "\"name\";\"Max\"}",
+            + "\"name\":\"Max\"}",
         json);
-  }
-
-  @Resource
-  public static class TopResource {
-
-    public String id = "1";
-
-    @Link public HALLink self = new HALLink.Builder(URI.create("/top/1")).build();
-
-    @Link("child")
-    public List<HALLink> childResourcesLink =
-        Arrays.asList(
-            new HALLink.Builder(URI.create("/top/1/child/1")).build(),
-            new HALLink.Builder(URI.create("/top/1/child/2")).build());
-
-    @EmbeddedResource("child")
-    public Collection<ChildResource> children =
-        Arrays.asList(new ChildResource("1"), new OtherChildResource("2", "Max"));
-  }
-
-  @Resource
-  public static class TopResourceWithoutEmbedded {
-    public String id = "1";
-
-    @Link public HALLink self = new HALLink.Builder(URI.create("/top/1")).build();
-
-    public Collection<ChildResource> children =
-        Arrays.asList(new ChildResource("1"), new OtherChildResource("2", "Max"));
   }
 
   @JsonTypeInfo(

--- a/src/test/java/io/openapitoools/jackson/dataformat/hal/ser/HALBeanSerializerPolymorphicWithPropertyIT.java
+++ b/src/test/java/io/openapitoools/jackson/dataformat/hal/ser/HALBeanSerializerPolymorphicWithPropertyIT.java
@@ -53,8 +53,8 @@ public class HALBeanSerializerPolymorphicWithPropertyIT {
             + "},"
             + "\"_embedded\":{"
             + "\"child\":["
-            + "{\"_links\":{\"self\":{\"href\":\"/top/1/child/1\"}},\"@type\":\"ChildResource\",\"id\":\"1\"},"
-            + "{\"_links\":{\"self\":{\"href\":\"/top/1/child/2\"}},\"@type\":\"OtherChildResource\",\"id\":\"2\",\"name\":\"Max\"}]"
+            + "{\"@type\":\"ChildResource\",\"_links\":{\"self\":{\"href\":\"/top/1/child/1\"}},\"id\":\"1\"},"
+            + "{\"@type\":\"OtherChildResource\",\"_links\":{\"self\":{\"href\":\"/top/1/child/2\"}},\"id\":\"2\",\"name\":\"Max\"}]"
             + "},"
             + "\"id\":\"1\"}",
         json);
@@ -81,8 +81,8 @@ public class HALBeanSerializerPolymorphicWithPropertyIT {
             + "},"
             + "\"id\":\"1\","
             + "\"children\":["
-            + "{\"_links\":{\"self\":{\"href\":\"/top/1/child/1\"}},\"@type\":\"ChildResource\",\"id\":\"1\"},"
-            + "{\"_links\":{\"self\":{\"href\":\"/top/1/child/2\"}},\"@type\":\"OtherChildResource\",\"id\":\"2\",\"name\":\"Max\"}]"
+            + "{\"@type\":\"ChildResource\",\"_links\":{\"self\":{\"href\":\"/top/1/child/1\"}},\"id\":\"1\"},"
+            + "{\"@type\":\"OtherChildResource\",\"_links\":{\"self\":{\"href\":\"/top/1/child/2\"}},\"id\":\"2\",\"name\":\"Max\"}]"
             + "}",
         json);
   }
@@ -107,7 +107,7 @@ public class HALBeanSerializerPolymorphicWithPropertyIT {
             + "\"self\":{\"href\":\"/top/1\"}"
             + "},"
             + "\"_embedded\":{"
-            + "\"child\":{\"_links\":{\"self\":{\"href\":\"/top/1/child/1\"}},\"@type\":\"ChildResource\",\"id\":\"1\"}"
+            + "\"child\":{\"@type\":\"ChildResource\",\"_links\":{\"self\":{\"href\":\"/top/1/child/1\"}},\"id\":\"1\"}"
             + "},"
             + "\"id\":\"1\"}",
         json);
@@ -133,7 +133,7 @@ public class HALBeanSerializerPolymorphicWithPropertyIT {
             + "},"
             + "\"id\":\"1\","
             + "\"child\":{"
-            + "\"_links\":{\"self\":{\"href\":\"/top/1/child/1\"}},\"@type\":\"ChildResource\",\"id\":\"1\""
+            + "\"@type\":\"ChildResource\",\"_links\":{\"self\":{\"href\":\"/top/1/child/1\"}},\"id\":\"1\""
             + "}}",
         json);
   }
@@ -144,10 +144,10 @@ public class HALBeanSerializerPolymorphicWithPropertyIT {
     String json = om.writeValueAsString(resource);
     assertEquals(
         "{"
+            + "\"@type\":\"ChildResource\","
             + "\"_links\":{"
             + "\"self\":{\"href\":\"/top/1/child/1\"}"
             + "},"
-            + "\"@type\":\"ChildResource\","
             + "\"id\":\"1\"}",
         json);
   }
@@ -158,10 +158,10 @@ public class HALBeanSerializerPolymorphicWithPropertyIT {
     String json = om.writeValueAsString(resource);
     assertEquals(
         "{"
+            + "\"@type\":\"OtherChildResource\","
             + "\"_links\":{"
             + "\"self\":{\"href\":\"/top/1/child/1\"}"
             + "},"
-            + "\"@type\":\"OtherChildResource\","
             + "\"id\":\"1\","
             + "\"name\":\"Max\"}",
         json);

--- a/src/test/java/io/openapitoools/jackson/dataformat/hal/ser/HALBeanSerializerPolymorphicWithPropertyIT.java
+++ b/src/test/java/io/openapitoools/jackson/dataformat/hal/ser/HALBeanSerializerPolymorphicWithPropertyIT.java
@@ -1,0 +1,199 @@
+package io.openapitoools.jackson.dataformat.hal.ser;
+
+import static org.junit.Assert.assertEquals;
+
+import com.fasterxml.jackson.annotation.JsonSubTypes;
+import com.fasterxml.jackson.annotation.JsonTypeInfo;
+import com.fasterxml.jackson.annotation.JsonTypeInfo.As;
+import com.fasterxml.jackson.annotation.JsonTypeInfo.Id;
+import com.fasterxml.jackson.annotation.JsonTypeName;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import io.openapitools.jackson.dataformat.hal.HALLink;
+import io.openapitools.jackson.dataformat.hal.HALMapper;
+import io.openapitools.jackson.dataformat.hal.annotation.EmbeddedResource;
+import io.openapitools.jackson.dataformat.hal.annotation.Link;
+import io.openapitools.jackson.dataformat.hal.annotation.Resource;
+import java.net.URI;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+import org.junit.Test;
+
+public class HALBeanSerializerPolymorphicWithPropertyIT {
+
+  ObjectMapper om = new HALMapper();
+
+  @Test
+  public void testSerializationForResourceWithEmbeddableList() throws Exception {
+    @Resource
+    class TopResource {
+
+      public String id = "1";
+
+      @Link public HALLink self = new HALLink.Builder(URI.create("/top/1")).build();
+
+      @Link("child")
+      public List<HALLink> childResourcesLink =
+          Arrays.asList(
+              new HALLink.Builder(URI.create("/top/1/child/1")).build(),
+              new HALLink.Builder(URI.create("/top/1/child/2")).build());
+
+      @EmbeddedResource("child")
+      public Collection<ChildResource> children =
+          Arrays.asList(new ChildResource("1"), new OtherChildResource("2", "Max"));
+    }
+
+    TopResource resource = new TopResource();
+    String json = om.writeValueAsString(resource);
+    assertEquals(
+        "{"
+            + "\"_links\":{"
+            + "\"child\":[{\"href\":\"/top/1/child/1\"},{\"href\":\"/top/1/child/2\"}],"
+            + "\"self\":{\"href\":\"/top/1\"}"
+            + "},"
+            + "\"_embedded\":{"
+            + "\"child\":["
+            + "{\"_links\":{\"self\":{\"href\":\"/top/1/child/1\"}},\"@type\":\"ChildResource\",\"id\":\"1\"},"
+            + "{\"_links\":{\"self\":{\"href\":\"/top/1/child/2\"}},\"@type\":\"OtherChildResource\",\"id\":\"2\",\"name\":\"Max\"}]"
+            + "},"
+            + "\"id\":\"1\"}",
+        json);
+  }
+
+  @Test
+  public void testSerializationForResourceWithList() throws Exception {
+    @Resource
+    class TopResourceWithoutEmbedded {
+      public String id = "1";
+
+      @Link public HALLink self = new HALLink.Builder(URI.create("/top/1")).build();
+
+      public Collection<ChildResource> children =
+          Arrays.asList(new ChildResource("1"), new OtherChildResource("2", "Max"));
+    }
+
+    TopResourceWithoutEmbedded resource = new TopResourceWithoutEmbedded();
+    String json = om.writeValueAsString(resource);
+    assertEquals(
+        "{"
+            + "\"_links\":{"
+            + "\"self\":{\"href\":\"/top/1\"}"
+            + "},"
+            + "\"id\":\"1\","
+            + "\"children\":["
+            + "{\"_links\":{\"self\":{\"href\":\"/top/1/child/1\"}},\"@type\":\"ChildResource\",\"id\":\"1\"},"
+            + "{\"_links\":{\"self\":{\"href\":\"/top/1/child/2\"}},\"@type\":\"OtherChildResource\",\"id\":\"2\",\"name\":\"Max\"}]"
+            + "}",
+        json);
+  }
+
+  @Test
+  public void testSerializationForResourceEmbedded() throws Exception {
+    @Resource
+    class SimpleTopResourceEmbedded {
+      public String id = "1";
+
+      @Link public HALLink self = new HALLink.Builder(URI.create("/top/1")).build();
+
+      @EmbeddedResource
+      public ChildResource child = new ChildResource("1");
+    }
+
+    SimpleTopResourceEmbedded resource = new SimpleTopResourceEmbedded();
+    String json = om.writeValueAsString(resource);
+    assertEquals(
+        "{"
+            + "\"_links\":{"
+            + "\"self\":{\"href\":\"/top/1\"}"
+            + "},"
+            + "\"_embedded\":{"
+            + "\"child\":{\"_links\":{\"self\":{\"href\":\"/top/1/child/1\"}},\"@type\":\"ChildResource\",\"id\":\"1\"}"
+            + "},"
+            + "\"id\":\"1\"}",
+        json);
+  }
+
+  @Test
+  public void testSerializationForResource() throws Exception {
+    @Resource
+    class SimpleTopResource {
+      public String id = "1";
+
+      @Link public HALLink self = new HALLink.Builder(URI.create("/top/1")).build();
+
+      public ChildResource child = new ChildResource("1");
+    }
+
+    SimpleTopResource resource = new SimpleTopResource();
+    String json = om.writeValueAsString(resource);
+    assertEquals(
+        "{"
+            + "\"_links\":{"
+            + "\"self\":{\"href\":\"/top/1\"}"
+            + "},"
+            + "\"id\":\"1\","
+            + "\"child\":{"
+            + "\"_links\":{\"self\":{\"href\":\"/top/1/child/1\"}},\"@type\":\"ChildResource\",\"id\":\"1\""
+            + "}}",
+        json);
+  }
+
+  @Test
+  public void testSerializationForAnnotatedPolymorphicObject() throws Exception {
+    ChildResource resource = new ChildResource("1");
+    String json = om.writeValueAsString(resource);
+    assertEquals(
+        "{"
+            + "\"_links\":{"
+            + "\"self\":{\"href\":\"/top/1/child/1\"}"
+            + "},"
+            + "\"@type\":\"ChildResource\","
+            + "\"id\":\"1\"}",
+        json);
+  }
+
+  @Test
+  public void testSerializationForNotAnnotatedPolymorphicObject() throws Exception {
+    ChildResource resource = new OtherChildResource("1", "Max");
+    String json = om.writeValueAsString(resource);
+    assertEquals(
+        "{"
+            + "\"_links\":{"
+            + "\"self\":{\"href\":\"/top/1/child/1\"}"
+            + "},"
+            + "\"@type\":\"OtherChildResource\","
+            + "\"id\":\"1\","
+            + "\"name\":\"Max\"}",
+        json);
+  }
+
+  @JsonTypeInfo(
+      use = Id.NAME,
+      include = As.PROPERTY,
+      defaultImpl = ChildResource.class)
+  @JsonSubTypes({@JsonSubTypes.Type(value = OtherChildResource.class, name = "OtherChildResource")})
+  @JsonTypeName("ChildResource")
+  @Resource
+  public static class ChildResource {
+    public String id;
+
+    @Link public HALLink self;
+
+    public ChildResource(String id) {
+      this.id = id;
+      self = new HALLink.Builder(URI.create("/top/1/child/" + id)).build();
+    }
+  }
+
+  @Resource
+  @JsonTypeName("OtherChildResource")
+  public static class OtherChildResource extends ChildResource {
+
+    public String name;
+
+    public OtherChildResource(String id, String name) {
+      super(id);
+      this.name = name;
+    }
+  }
+}


### PR DESCRIPTION
This PR includes the prepared tests of #24 (he is my co-worker) and fixes the issue #25.

This PR solves two issues:
1. When a class is annotated with `@JsonTypeInfo(...)`, `jackson-databind` wraps the `HALBeanSerializer` into a [`TypeWrappedSerializer`](https://github.com/FasterXML/jackson-databind/blob/c3b86568c3faa52fb5ac1361f857b4d01fee3fe6/src/main/java/com/fasterxml/jackson/databind/ser/impl/TypeWrappedSerializer.java) and serializes this instead. When calling the wrapped serializer, it uses the `serializeWithType(...)` method instead of the `serialize(...)` of `HALBeanSerializer`. This function is not implemented by the `HALBeanSerializer` so the custom serialize function is not called. This is solved by implementing the `serializeWithType(...)` function that writes the type information and starts the custom HAL serializer.
2. The type information is not correctly included in embedded fields since the check for the `@JsonTypeInfo(...)` is skipped in the current implementation. This is solved by not writing the embedded object directly, but by serializing it like all other properties with `prop.serializeAsField(...)`. Since the name of the property might change due to a custom relation name in the `@EmbeddedResource(name)`, the name needs to be replaced in the property to be serialized correctly.

There is some more code in [BeanSerializerBase#serializeWithType](https://github.com/FasterXML/jackson-databind/blob/15f943707bb046a6c482dd7d0c4d0404b84b7720/src/main/java/com/fasterxml/jackson/databind/ser/std/BeanSerializerBase.java#L588) where I don't know if we need that in the overridden function and I didn't include that.

Closes #24 #25

PS: In case you like and merge this PR, we would be happy if you could also create a release soon so we can import it into our applications.