### PR TITLE
Allow Strings and URIs for the @Link annotation when serializing

### DIFF
--- a/src/main/java/io/openapitools/jackson/dataformat/hal/ser/HALBeanSerializer.java
+++ b/src/main/java/io/openapitools/jackson/dataformat/hal/ser/HALBeanSerializer.java
@@ -16,6 +16,7 @@ import io.openapitools.jackson.dataformat.hal.annotation.Curies;
 import io.openapitools.jackson.dataformat.hal.annotation.EmbeddedResource;
 import io.openapitools.jackson.dataformat.hal.annotation.Link;
 import java.io.IOException;
+import java.net.URI;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -127,6 +128,10 @@ public class HALBeanSerializer extends BeanSerializerBase {
                             addLinks(relation, (Collection<HALLink>) prop.get(bean), curie);
                         } else if (value instanceof HALLink) {
                             addLink(relation, (HALLink) prop.get(bean), curie);
+                        } else if (value instanceof String) {
+                            addLink(relation, new HALLink.Builder((String) value).build(), curie);
+                        } else if (value instanceof URI) {
+                            addLink(relation, new HALLink.Builder((URI) value).build(), curie);
                         }
 
                     } else {

--- a/src/test/java/io/openapitoools/jackson/dataformat/hal/ser/HALBeanSerializerIT.java
+++ b/src/test/java/io/openapitoools/jackson/dataformat/hal/ser/HALBeanSerializerIT.java
@@ -2,6 +2,7 @@ package io.openapitoools.jackson.dataformat.hal.ser;
 
 
 import java.net.URI;
+import java.net.URISyntaxException;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
@@ -28,7 +29,9 @@ public class HALBeanSerializerIT {
                 + "\"child\":[{\"href\":\"/top/1/child/1\"},{\"href\":\"/top/1/child/2\"}],"
                 + "\"empty:list\":[],"
                 + "\"self\":{\"href\":\"/top/1\"},"
-                + "\"templated\":{\"href\":\"/uri/{id}\",\"templated\":true}"
+                + "\"stringLink\":{\"href\":\"http://something.com\",\"templated\":false},"
+                + "\"templated\":{\"href\":\"/uri/{id}\",\"templated\":true},"
+                + "\"uriLink\":{\"href\":\"http://something.else.com\"}"
                 + "},"
                 + "\"_embedded\":{"
                 + "\"child\":["
@@ -49,6 +52,12 @@ public class HALBeanSerializerIT {
 
         @Link("child")
         public HALLink childLink = new HALLink.Builder(URI.create("/should/be/overridden")).build();
+
+        @Link
+        public String stringLink = "http://something.com";
+
+        @Link
+        public URI uriLink = new URI("http://something.else.com");
 
         @Link
         public HALLink templated = new HALLink.Builder("/uri/{id}").build();
@@ -75,6 +84,9 @@ public class HALBeanSerializerIT {
 
         @EmbeddedResource
         public String nullString = null;
+
+        public TopResource() throws URISyntaxException {
+        }
     }
 
     @Resource


### PR DESCRIPTION
With this PR, it becomes possible to use the `@Link` annotation with Strings and URIs making the library less intrusive and easier to use.

Code Example:

```
        @Link
        public String stringLink = "http://something.com";

        @Link
        public URI uriLink = new URI("http://something.else.com");
```