### PR TITLE
Update dependencies and refactor to JUnit 5

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,13 @@
+# top-most EditorConfig file
+root = true
+
+# Unix-style newlines with a newline ending every file
+[*]
+end_of_line = lf
+insert_final_newline = true
+
+# Indentation style for Java
+[*.java]
+charset = utf-8
+indent_style = space
+indent_size = 4

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,195 @@
-target/
+# Created by https://www.toptal.com/developers/gitignore/api/java,maven,eclipse,intellij+all,code-java
+# Edit at https://www.toptal.com/developers/gitignore?templates=java,maven,eclipse,intellij+all,code-java
+
+### Code-Java ###
+# Language Support for Java(TM) by Red Hat extension for Visual Studio Code - https://marketplace.visualstudio.com/items?itemName=redhat.java
+
+.project
+.classpath
+factoryConfiguration.json
+
+### Eclipse ###
+.metadata
+bin/
+tmp/
+*.tmp
+*.bak
+*.swp
+*~.nib
+local.properties
+.settings/
+.loadpath
+.recommenders
+
+# External tool builders
+.externalToolBuilders/
+
+# Locally stored "Eclipse launch configurations"
+*.launch
+
+# PyDev specific (Python IDE for Eclipse)
+*.pydevproject
+
+# CDT-specific (C/C++ Development Tooling)
+.cproject
+
+# CDT- autotools
+.autotools
+
+# Java annotation processor (APT)
+.factorypath
+
+# PDT-specific (PHP Development Tools)
+.buildpath
+
+# sbteclipse plugin
+.target
+
+# Tern plugin
+.tern-project
+
+# TeXlipse plugin
+.texlipse
+
+# STS (Spring Tool Suite)
+.springBeans
+
+# Code Recommenders
+.recommenders/
+
+# Annotation Processing
+.apt_generated/
+.apt_generated_test/
+
+# Scala IDE specific (Scala & Java development for Eclipse)
+.cache-main
+.scala_dependencies
+.worksheet
+
+# Uncomment this line if you wish to ignore the project description file.
+# Typically, this file would be tracked if it contains build/dependency configurations:
+#.project
+
+### Eclipse Patch ###
+# Spring Boot Tooling
+.sts4-cache/
+
+### Intellij+all ###
+# Covers JetBrains IDEs: IntelliJ, RubyMine, PhpStorm, AppCode, PyCharm, CLion, Android Studio, WebStorm and Rider
+# Reference: https://intellij-support.jetbrains.com/hc/en-us/articles/206544839
+
+# User-specific stuff
+.idea/**/workspace.xml
+.idea/**/tasks.xml
+.idea/**/usage.statistics.xml
+.idea/**/dictionaries
+.idea/**/shelf
+
+# Generated files
+.idea/**/contentModel.xml
+
+# Sensitive or high-churn files
+.idea/**/dataSources/
+.idea/**/dataSources.ids
+.idea/**/dataSources.local.xml
+.idea/**/sqlDataSources.xml
+.idea/**/dynamic.xml
+.idea/**/uiDesigner.xml
+.idea/**/dbnavigator.xml
+
+# Gradle
+.idea/**/gradle.xml
+.idea/**/libraries
+
+# Gradle and Maven with auto-import
+# When using Gradle or Maven with auto-import, you should exclude module files,
+# since they will be recreated, and may cause churn.  Uncomment if using
+# auto-import.
+# .idea/artifacts
+# .idea/compiler.xml
+# .idea/jarRepositories.xml
+# .idea/modules.xml
+# .idea/*.iml
+# .idea/modules
+# *.iml
+# *.ipr
+
+# CMake
+cmake-build-*/
+
+# Mongo Explorer plugin
+.idea/**/mongoSettings.xml
+
+# File-based project format
+*.iws
+
+# IntelliJ
+out/
+
+# mpeltonen/sbt-idea plugin
+.idea_modules/
+
+# JIRA plugin
+atlassian-ide-plugin.xml
+
+# Cursive Clojure plugin
+.idea/replstate.xml
+
+# Crashlytics plugin (for Android Studio and IntelliJ)
+com_crashlytics_export_strings.xml
+crashlytics.properties
+crashlytics-build.properties
+fabric.properties
+
+# Editor-based Rest Client
+.idea/httpRequests
+
+# Android studio 3.1+ serialized cache file
+.idea/caches/build_file_checksums.ser
+
+### Intellij+all Patch ###
+# Ignores the whole .idea folder and all .iml files
+# See https://github.com/joeblau/gitignore.io/issues/186 and https://github.com/joeblau/gitignore.io/issues/360
+
 .idea/
+
+# Reason: https://github.com/joeblau/gitignore.io/issues/186#issuecomment-249601023
+
 *.iml
+modules.xml
+.idea/misc.xml
+*.ipr
+
+# Sonarlint plugin
+.idea/sonarlint
+
+### Java ###
+# Compiled class file
+*.class
+
+# Log file
+*.log
+
+# BlueJ files
+*.ctxt
+
+# Mobile Tools for Java (J2ME)
+.mtj.tmp/
+
+# Package Files #
+*.jar
+*.war
+*.nar
+*.ear
+*.zip
+*.tar.gz
+*.rar
+
+# virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
+hs_err_pid*
+
+### Maven ###
+target/
 pom.xml.tag
 pom.xml.releaseBackup
 pom.xml.versionsBackup
@@ -9,3 +198,7 @@ release.properties
 dependency-reduced-pom.xml
 buildNumber.properties
 .mvn/timing.properties
+# https://github.com/takari/maven-wrapper#usage-without-binary-jar
+.mvn/wrapper/maven-wrapper.jar
+
+# End of https://www.toptal.com/developers/gitignore/api/java,maven,eclipse,intellij+all,code-java

--- a/pom.xml
+++ b/pom.xml
@@ -49,10 +49,10 @@
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <com.fasterxml.jackson.version>2.10.2</com.fasterxml.jackson.version>
-        <junit.version>4.12</junit.version>
-        <org.mockito.version>2.2.28</org.mockito.version>
-        <org.slf4j.version>1.7.21</org.slf4j.version>
+        <com.fasterxml.jackson.version>2.11.3</com.fasterxml.jackson.version>
+        <junit.version>5.7.0</junit.version>
+        <org.mockito.version>3.6.28</org.mockito.version>
+        <org.slf4j.version>1.7.30</org.slf4j.version>
     </properties>
 
     <dependencies>
@@ -67,9 +67,15 @@
             <version>${org.slf4j.version}</version>
         </dependency>
 
+		<dependency>
+        	<groupId>org.junit.jupiter</groupId>
+        	<artifactId>junit-jupiter-api</artifactId>
+        	<version>${junit.version}</version>
+        	<scope>test</scope>
+    	</dependency>
         <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
+            <groupId>org.junit.jupiter</groupId>
+            <artifactId>junit-jupiter-engine</artifactId>
             <version>${junit.version}</version>
             <scope>test</scope>
         </dependency>

--- a/src/test/java/io/openapitoools/jackson/dataformat/hal/deser/CurieMapTest.java
+++ b/src/test/java/io/openapitoools/jackson/dataformat/hal/deser/CurieMapTest.java
@@ -1,8 +1,9 @@
 package io.openapitoools.jackson.dataformat.hal.deser;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
 import java.net.URI;
 
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import io.openapitools.jackson.dataformat.hal.deser.CurieMap;
@@ -13,7 +14,7 @@ public class CurieMapTest {
     public void testBasicSubstitution() {
         CurieMap cm = new CurieMap(new CurieMap.Mapping("prefix", "https://www.example.com/doc/{rel}"));
         URI uri = cm.resolve("prefix:reference").get();
-        Assertions.assertEquals(URI.create("https://www.example.com/doc/reference"), uri);
+        assertEquals(URI.create("https://www.example.com/doc/reference"), uri);
     }
 
 }

--- a/src/test/java/io/openapitoools/jackson/dataformat/hal/deser/CurieMapTest.java
+++ b/src/test/java/io/openapitoools/jackson/dataformat/hal/deser/CurieMapTest.java
@@ -1,10 +1,11 @@
 package io.openapitoools.jackson.dataformat.hal.deser;
 
-import io.openapitools.jackson.dataformat.hal.deser.CurieMap;
 import java.net.URI;
-import org.junit.Test;
 
-import static org.junit.Assert.assertEquals;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+import io.openapitools.jackson.dataformat.hal.deser.CurieMap;
 
 public class CurieMapTest {
 
@@ -12,7 +13,7 @@ public class CurieMapTest {
     public void testBasicSubstitution() {
         CurieMap cm = new CurieMap(new CurieMap.Mapping("prefix", "https://www.example.com/doc/{rel}"));
         URI uri = cm.resolve("prefix:reference").get();
-        assertEquals(URI.create("https://www.example.com/doc/reference"), uri);
+        Assertions.assertEquals(URI.create("https://www.example.com/doc/reference"), uri);
     }
 
 }

--- a/src/test/java/io/openapitoools/jackson/dataformat/hal/deser/HALBeanDeserializerIT.java
+++ b/src/test/java/io/openapitoools/jackson/dataformat/hal/deser/HALBeanDeserializerIT.java
@@ -1,17 +1,19 @@
 package io.openapitoools.jackson.dataformat.hal.deser;
 
+import java.io.StringReader;
+import java.util.Collection;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
 import com.fasterxml.jackson.databind.ObjectMapper;
+
 import io.openapitools.jackson.dataformat.hal.HALLink;
 import io.openapitools.jackson.dataformat.hal.HALMapper;
 import io.openapitools.jackson.dataformat.hal.annotation.EmbeddedResource;
 import io.openapitools.jackson.dataformat.hal.annotation.Link;
 import io.openapitools.jackson.dataformat.hal.annotation.Resource;
-import java.io.StringReader;
-import java.util.Collection;
-import org.junit.Test;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
 
 public class HALBeanDeserializerIT {
     static final String HAL_DOC = "{"
@@ -34,26 +36,26 @@ public class HALBeanDeserializerIT {
     @Test
     public void testDeserialization() throws Exception {
         TopResource tr = om.readValue(new StringReader(HAL_DOC), TopResource.class);
-        assertEquals("1", tr.id);
-        assertEquals("/top/1", tr.self.getHref());
-        assertEquals("/uri/{id}", tr.templated.getHref());
-        assertTrue(tr.templated.getTemplated());
-        assertEquals(2, tr.childLinks.size());
-        assertEquals(2, tr.children.size());
+        Assertions.assertEquals("1", tr.id);
+        Assertions.assertEquals("/top/1", tr.self.getHref());
+        Assertions.assertEquals("/uri/{id}", tr.templated.getHref());
+        Assertions.assertTrue(tr.templated.getTemplated());
+        Assertions.assertEquals(2, tr.childLinks.size());
+        Assertions.assertEquals(2, tr.children.size());
         System.out.println("tr: " + tr);
     }
 
     @Test
     public void testDetailedDeserialization() throws Exception {
         TopResource tr = om.readValue(new StringReader(HAL_DOC), TopResource.class);
-        assertEquals("1", tr.id);
-        assertEquals("/top/1", tr.self.getHref());
-        assertEquals("/uri/{id}", tr.templated.getHref());
-        assertTrue(tr.templated.getTemplated());
-        assertEquals("top-title", tr.templated.getTitle());
-        assertEquals("2017-08-10Z22:00:00", tr.templated.getSeen());        
-        assertEquals(2, tr.childLinks.size());
-        assertEquals(2, tr.children.size());
+        Assertions.assertEquals("1", tr.id);
+        Assertions.assertEquals("/top/1", tr.self.getHref());
+        Assertions.assertEquals("/uri/{id}", tr.templated.getHref());
+        Assertions.assertTrue(tr.templated.getTemplated());
+        Assertions.assertEquals("top-title", tr.templated.getTitle());
+        Assertions.assertEquals("2017-08-10Z22:00:00", tr.templated.getSeen());
+        Assertions.assertEquals(2, tr.childLinks.size());
+        Assertions.assertEquals(2, tr.children.size());
         System.out.println("tr: " + tr);
     }
 
@@ -95,5 +97,5 @@ public class HALBeanDeserializerIT {
         @Link
         public HALLink self;
     }
-    
+
 }

--- a/src/test/java/io/openapitoools/jackson/dataformat/hal/deser/HALBeanDeserializerIT.java
+++ b/src/test/java/io/openapitoools/jackson/dataformat/hal/deser/HALBeanDeserializerIT.java
@@ -1,9 +1,11 @@
 package io.openapitoools.jackson.dataformat.hal.deser;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import java.io.StringReader;
 import java.util.Collection;
 
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -36,26 +38,26 @@ public class HALBeanDeserializerIT {
     @Test
     public void testDeserialization() throws Exception {
         TopResource tr = om.readValue(new StringReader(HAL_DOC), TopResource.class);
-        Assertions.assertEquals("1", tr.id);
-        Assertions.assertEquals("/top/1", tr.self.getHref());
-        Assertions.assertEquals("/uri/{id}", tr.templated.getHref());
-        Assertions.assertTrue(tr.templated.getTemplated());
-        Assertions.assertEquals(2, tr.childLinks.size());
-        Assertions.assertEquals(2, tr.children.size());
+        assertEquals("1", tr.id);
+        assertEquals("/top/1", tr.self.getHref());
+        assertEquals("/uri/{id}", tr.templated.getHref());
+        assertTrue(tr.templated.getTemplated());
+        assertEquals(2, tr.childLinks.size());
+        assertEquals(2, tr.children.size());
         System.out.println("tr: " + tr);
     }
 
     @Test
     public void testDetailedDeserialization() throws Exception {
         TopResource tr = om.readValue(new StringReader(HAL_DOC), TopResource.class);
-        Assertions.assertEquals("1", tr.id);
-        Assertions.assertEquals("/top/1", tr.self.getHref());
-        Assertions.assertEquals("/uri/{id}", tr.templated.getHref());
-        Assertions.assertTrue(tr.templated.getTemplated());
-        Assertions.assertEquals("top-title", tr.templated.getTitle());
-        Assertions.assertEquals("2017-08-10Z22:00:00", tr.templated.getSeen());
-        Assertions.assertEquals(2, tr.childLinks.size());
-        Assertions.assertEquals(2, tr.children.size());
+        assertEquals("1", tr.id);
+        assertEquals("/top/1", tr.self.getHref());
+        assertEquals("/uri/{id}", tr.templated.getHref());
+        assertTrue(tr.templated.getTemplated());
+        assertEquals("top-title", tr.templated.getTitle());
+        assertEquals("2017-08-10Z22:00:00", tr.templated.getSeen());
+        assertEquals(2, tr.childLinks.size());
+        assertEquals(2, tr.children.size());
         System.out.println("tr: " + tr);
     }
 

--- a/src/test/java/io/openapitoools/jackson/dataformat/hal/deser/HALBeanDeserializerMethodAnnIT.java
+++ b/src/test/java/io/openapitoools/jackson/dataformat/hal/deser/HALBeanDeserializerMethodAnnIT.java
@@ -1,8 +1,16 @@
 package io.openapitoools.jackson.dataformat.hal.deser;
 
 
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.exc.UnrecognizedPropertyException;
+
 import io.openapitools.jackson.dataformat.hal.HALLink;
 import io.openapitools.jackson.dataformat.hal.HALMapper;
 import io.openapitools.jackson.dataformat.hal.annotation.Curie;
@@ -10,16 +18,6 @@ import io.openapitools.jackson.dataformat.hal.annotation.Curies;
 import io.openapitools.jackson.dataformat.hal.annotation.EmbeddedResource;
 import io.openapitools.jackson.dataformat.hal.annotation.Link;
 import io.openapitools.jackson.dataformat.hal.annotation.Resource;
-import org.junit.Test;
-
-import java.io.IOException;
-import java.util.HashMap;
-import java.util.Map;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNull;
-import static org.junit.Assert.fail;
 
 /**
  * Verify that HAL annotations can be used on methods as well as fields.
@@ -35,7 +33,7 @@ public class HALBeanDeserializerMethodAnnIT {
                 "    \"curies\": [{" +
                 "      \"href\": \"http://my.example.com/doc/{rel}\"," +
                 "      \"name\": \"cur1\"," +
-                "      \"templated\": true" +             
+                "      \"templated\": true" +
                 "    }]," +
                 "    \"self\": {" +
                 "      \"href\": \"http://self.url\"," +
@@ -52,16 +50,16 @@ public class HALBeanDeserializerMethodAnnIT {
                 "}";
 
         TestSingleCurieResource resource = om.readValue(json, TestSingleCurieResource.class);
-        assertEquals("POJO name", resource.fields.get("name"));
+        Assertions.assertEquals("POJO name", resource.fields.get("name"));
 
         HALLink self = (HALLink) resource.fields.get("self");
-        assertEquals("http://self.url", self.getHref());
-        assertFalse(self.getTemplated());
+        Assertions.assertEquals("http://self.url", self.getHref());
+        Assertions.assertFalse(self.getTemplated());
 
         HALLink other = (HALLink) resource.fields.get("otherlink");
-        assertEquals("http://other.link.url", other.getHref());
+        Assertions.assertEquals("http://other.link.url", other.getHref());
 
-        assertEquals("the more you know", resource.fields.get("extras"));        
+        Assertions.assertEquals("the more you know", resource.fields.get("extras"));
     }
 
     @Test
@@ -76,7 +74,7 @@ public class HALBeanDeserializerMethodAnnIT {
                 "    },{" +
                 "      \"href\": \"http://docs.myother.site/cur2\"," +
                 "      \"name\": \"cur2\"," +
-                "      \"templated\": false" +                
+                "      \"templated\": false" +
                 "    }]," +
                 "    \"self\": {" +
                 "      \"href\": \"http://self.url\"," +
@@ -89,7 +87,7 @@ public class HALBeanDeserializerMethodAnnIT {
                 "    \"cur1:link2\": {" +
                 "      \"href\": \"http://link2.url\"," +
                 "      \"templated\": true" +
-                "    }," +            
+                "    }," +
                 "    \"cur2:link3\": {" +
                 "      \"href\": \"http://link3.url{?id}\"," +
                 "      \"templated\": true" +
@@ -102,27 +100,27 @@ public class HALBeanDeserializerMethodAnnIT {
 
 
         TestCuriesResource resource = om.readValue(json, TestCuriesResource.class);
-        assertEquals("POJO name", resource.fields.get("name"));
+        Assertions.assertEquals("POJO name", resource.fields.get("name"));
 
         HALLink self = (HALLink) resource.fields.get("self");
-        assertEquals("http://self.url", self.getHref());
-        assertFalse(self.getTemplated());
+        Assertions.assertEquals("http://self.url", self.getHref());
+        Assertions.assertFalse(self.getTemplated());
 
         HALLink other = (HALLink) resource.fields.get("otherlink");
-        assertEquals("http://other.link.url", other.getHref());
+        Assertions.assertEquals("http://other.link.url", other.getHref());
 
         HALLink curie2 = (HALLink) resource.fields.get("link2");
-        assertEquals("http://link2.url", curie2.getHref());
-        assertEquals(true, curie2.getTemplated());
-        
+        Assertions.assertEquals("http://link2.url", curie2.getHref());
+        Assertions.assertEquals(true, curie2.getTemplated());
+
         HALLink curie3 = (HALLink) resource.fields.get("link3");
-        assertEquals("http://link3.url{?id}", curie3.getHref());
-        assertEquals(true, curie3.getTemplated());
+        Assertions.assertEquals("http://link3.url{?id}", curie3.getHref());
+        Assertions.assertEquals(true, curie3.getTemplated());
 
         HALLink curie4 = (HALLink) resource.fields.get("link4");
-        assertNull(curie4);
-       
-        assertEquals("the more you know", resource.fields.get("extras"));        
+        Assertions.assertNull(curie4);
+
+        Assertions.assertEquals("the more you know", resource.fields.get("extras"));
     }
 
     @Test
@@ -163,27 +161,27 @@ public class HALBeanDeserializerMethodAnnIT {
 
 
         TestCuriesResource resource = om.readValue(json, TestCuriesResource.class);
-        assertEquals("POJO name", resource.fields.get("name"));
+        Assertions.assertEquals("POJO name", resource.fields.get("name"));
 
         HALLink self = (HALLink) resource.fields.get("self");
-        assertEquals("http://self.url", self.getHref());
-        assertFalse(self.getTemplated());
+        Assertions.assertEquals("http://self.url", self.getHref());
+        Assertions.assertFalse(self.getTemplated());
 
         HALLink other = (HALLink) resource.fields.get("otherlink");
-        assertEquals("http://other.link.url", other.getHref());
+        Assertions.assertEquals("http://other.link.url", other.getHref());
 
         HALLink curie2 = (HALLink) resource.fields.get("link2");
-        assertEquals("http://link2.url", curie2.getHref());
-        assertEquals(true, curie2.getTemplated());
+        Assertions.assertEquals("http://link2.url", curie2.getHref());
+        Assertions.assertEquals(true, curie2.getTemplated());
 
         HALLink curie3 = (HALLink) resource.fields.get("link3");
-        assertEquals("http://link3.url{?id}", curie3.getHref());
-        assertEquals(true, curie3.getTemplated());
+        Assertions.assertEquals("http://link3.url{?id}", curie3.getHref());
+        Assertions.assertEquals(true, curie3.getTemplated());
 
         HALLink curie4 = (HALLink) resource.fields.get("link4");
-        assertNull(curie4);
+        Assertions.assertNull(curie4);
 
-        assertEquals("the more you know", resource.fields.get("extras"));
+        Assertions.assertEquals("the more you know", resource.fields.get("extras"));
     }
 
      @Test
@@ -198,7 +196,7 @@ public class HALBeanDeserializerMethodAnnIT {
                 "    },{" +
                 "      \"href\": \"http://docs.myother.site/cur2\"," +
                 "      \"name\": \"cur2\"," +
-                "      \"templated\": false" +                
+                "      \"templated\": false" +
                 "    }]," +
                 "    \"self\": {" +
                 "      \"href\": \"http://self.url\"," +
@@ -211,11 +209,11 @@ public class HALBeanDeserializerMethodAnnIT {
                 "    \"cur1:link2\": {" +
                 "      \"href\": \"http://link2.url\"," +
                 "      \"templated\": true" +
-                "    }," +            
+                "    }," +
                 "    \"cur2:link3\": {" +
                 "      \"href\": \"http://link3.url{?id}\"," +
                 "      \"templated\": true" +
-                "    }," +            
+                "    }," +
                 "    \"cur3:extralink\": {" +
                 "      \"href\": \"http://extralink.url\"," +
                 "      \"templated\": false" +
@@ -228,8 +226,8 @@ public class HALBeanDeserializerMethodAnnIT {
 
 
         try {
-            TestCuriesResource resource = om.readValue(json, TestCuriesResource.class);
-            fail("There should be a failure due to non-defined query");
+            om.readValue(json, TestCuriesResource.class);
+            Assertions.fail("There should be a failure due to non-defined query");
         } catch (UnrecognizedPropertyException upe) {
             //ignore
         }
@@ -247,7 +245,7 @@ public class HALBeanDeserializerMethodAnnIT {
                 "    },{" +
                 "      \"href\": \"http://docs.myother.site/cur2\"," +
                 "      \"name\": \"cur2\"," +
-                "      \"templated\": false" +                
+                "      \"templated\": false" +
                 "    }]," +
                 "    \"self\": {" +
                 "      \"href\": \"http://self.url\"," +
@@ -260,7 +258,7 @@ public class HALBeanDeserializerMethodAnnIT {
                 "    \"cur1:link2\": {" +
                 "      \"href\": \"/link2.url\"," +
                 "      \"templated\": true" +
-                "    }," +            
+                "    }," +
                 "    \"cur2:link3\": {" +
                 "      \"href\": \"http://link3.url{?id}\"," +
                 "      \"templated\": true" +
@@ -273,27 +271,27 @@ public class HALBeanDeserializerMethodAnnIT {
 
 
         TestCuriesResource resource = om.readValue(json, TestCuriesResource.class);
-        assertEquals("POJO name", resource.fields.get("name"));
+        Assertions.assertEquals("POJO name", resource.fields.get("name"));
 
         HALLink self = (HALLink) resource.fields.get("self");
-        assertEquals("http://self.url", self.getHref());
-        assertFalse(self.getTemplated());
+        Assertions.assertEquals("http://self.url", self.getHref());
+        Assertions.assertFalse(self.getTemplated());
 
         HALLink other = (HALLink) resource.fields.get("otherlink");
-        assertEquals("http://other.link.url", other.getHref());
+        Assertions.assertEquals("http://other.link.url", other.getHref());
 
         HALLink curie2 = (HALLink) resource.fields.get("link2");
-        assertEquals("/link2.url", curie2.getHref());
-        assertEquals(true, curie2.getTemplated());
-        
+        Assertions.assertEquals("/link2.url", curie2.getHref());
+        Assertions.assertEquals(true, curie2.getTemplated());
+
         HALLink curie3 = (HALLink) resource.fields.get("link3");
-        assertEquals("http://link3.url{?id}", curie3.getHref());
-        assertEquals(true, curie3.getTemplated());
+        Assertions.assertEquals("http://link3.url{?id}", curie3.getHref());
+        Assertions.assertEquals(true, curie3.getTemplated());
 
         HALLink curie4 = (HALLink) resource.fields.get("link4");
-        assertNull(curie4);
-       
-        assertEquals("the more you know", resource.fields.get("extras"));        
+        Assertions.assertNull(curie4);
+
+        Assertions.assertEquals("the more you know", resource.fields.get("extras"));
     }
 
     @Test
@@ -327,8 +325,8 @@ public class HALBeanDeserializerMethodAnnIT {
         TestCuriesResource resource = om.readValue(json, TestCuriesResource.class);
 
         HALLink link2 = (HALLink) resource.fields.get("link2");
-        assertEquals("http://link2.url", link2.getHref());
-        assertEquals(true, link2.getTemplated());
+        Assertions.assertEquals("http://link2.url", link2.getHref());
+        Assertions.assertEquals(true, link2.getTemplated());
     }
 
 
@@ -362,7 +360,7 @@ public class HALBeanDeserializerMethodAnnIT {
             fields.put("extras", extras);
         }
     }
-    
+
    @Curies({@Curie(href = "http://docs.my.site/{rel}", prefix = "cur1"),
              @Curie(href = "http://docs.myother.site/cur2", prefix = "cur2"),
              @Curie(href = "http://docs.another.site/{rel}", prefix = "cur3"),

--- a/src/test/java/io/openapitoools/jackson/dataformat/hal/deser/HALBeanDeserializerMethodAnnIT.java
+++ b/src/test/java/io/openapitoools/jackson/dataformat/hal/deser/HALBeanDeserializerMethodAnnIT.java
@@ -1,11 +1,14 @@
 package io.openapitoools.jackson.dataformat.hal.deser;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -50,16 +53,16 @@ public class HALBeanDeserializerMethodAnnIT {
                 "}";
 
         TestSingleCurieResource resource = om.readValue(json, TestSingleCurieResource.class);
-        Assertions.assertEquals("POJO name", resource.fields.get("name"));
+        assertEquals("POJO name", resource.fields.get("name"));
 
         HALLink self = (HALLink) resource.fields.get("self");
-        Assertions.assertEquals("http://self.url", self.getHref());
-        Assertions.assertFalse(self.getTemplated());
+        assertEquals("http://self.url", self.getHref());
+        assertFalse(self.getTemplated());
 
         HALLink other = (HALLink) resource.fields.get("otherlink");
-        Assertions.assertEquals("http://other.link.url", other.getHref());
+        assertEquals("http://other.link.url", other.getHref());
 
-        Assertions.assertEquals("the more you know", resource.fields.get("extras"));
+        assertEquals("the more you know", resource.fields.get("extras"));
     }
 
     @Test
@@ -100,27 +103,27 @@ public class HALBeanDeserializerMethodAnnIT {
 
 
         TestCuriesResource resource = om.readValue(json, TestCuriesResource.class);
-        Assertions.assertEquals("POJO name", resource.fields.get("name"));
+        assertEquals("POJO name", resource.fields.get("name"));
 
         HALLink self = (HALLink) resource.fields.get("self");
-        Assertions.assertEquals("http://self.url", self.getHref());
-        Assertions.assertFalse(self.getTemplated());
+        assertEquals("http://self.url", self.getHref());
+        assertFalse(self.getTemplated());
 
         HALLink other = (HALLink) resource.fields.get("otherlink");
-        Assertions.assertEquals("http://other.link.url", other.getHref());
+        assertEquals("http://other.link.url", other.getHref());
 
         HALLink curie2 = (HALLink) resource.fields.get("link2");
-        Assertions.assertEquals("http://link2.url", curie2.getHref());
-        Assertions.assertEquals(true, curie2.getTemplated());
+        assertEquals("http://link2.url", curie2.getHref());
+        assertEquals(true, curie2.getTemplated());
 
         HALLink curie3 = (HALLink) resource.fields.get("link3");
-        Assertions.assertEquals("http://link3.url{?id}", curie3.getHref());
-        Assertions.assertEquals(true, curie3.getTemplated());
+        assertEquals("http://link3.url{?id}", curie3.getHref());
+        assertEquals(true, curie3.getTemplated());
 
         HALLink curie4 = (HALLink) resource.fields.get("link4");
-        Assertions.assertNull(curie4);
+        assertNull(curie4);
 
-        Assertions.assertEquals("the more you know", resource.fields.get("extras"));
+        assertEquals("the more you know", resource.fields.get("extras"));
     }
 
     @Test
@@ -161,27 +164,27 @@ public class HALBeanDeserializerMethodAnnIT {
 
 
         TestCuriesResource resource = om.readValue(json, TestCuriesResource.class);
-        Assertions.assertEquals("POJO name", resource.fields.get("name"));
+        assertEquals("POJO name", resource.fields.get("name"));
 
         HALLink self = (HALLink) resource.fields.get("self");
-        Assertions.assertEquals("http://self.url", self.getHref());
-        Assertions.assertFalse(self.getTemplated());
+        assertEquals("http://self.url", self.getHref());
+        assertFalse(self.getTemplated());
 
         HALLink other = (HALLink) resource.fields.get("otherlink");
-        Assertions.assertEquals("http://other.link.url", other.getHref());
+        assertEquals("http://other.link.url", other.getHref());
 
         HALLink curie2 = (HALLink) resource.fields.get("link2");
-        Assertions.assertEquals("http://link2.url", curie2.getHref());
-        Assertions.assertEquals(true, curie2.getTemplated());
+        assertEquals("http://link2.url", curie2.getHref());
+        assertEquals(true, curie2.getTemplated());
 
         HALLink curie3 = (HALLink) resource.fields.get("link3");
-        Assertions.assertEquals("http://link3.url{?id}", curie3.getHref());
-        Assertions.assertEquals(true, curie3.getTemplated());
+        assertEquals("http://link3.url{?id}", curie3.getHref());
+        assertEquals(true, curie3.getTemplated());
 
         HALLink curie4 = (HALLink) resource.fields.get("link4");
-        Assertions.assertNull(curie4);
+        assertNull(curie4);
 
-        Assertions.assertEquals("the more you know", resource.fields.get("extras"));
+        assertEquals("the more you know", resource.fields.get("extras"));
     }
 
      @Test
@@ -227,7 +230,7 @@ public class HALBeanDeserializerMethodAnnIT {
 
         try {
             om.readValue(json, TestCuriesResource.class);
-            Assertions.fail("There should be a failure due to non-defined query");
+            fail("There should be a failure due to non-defined query");
         } catch (UnrecognizedPropertyException upe) {
             //ignore
         }
@@ -271,27 +274,27 @@ public class HALBeanDeserializerMethodAnnIT {
 
 
         TestCuriesResource resource = om.readValue(json, TestCuriesResource.class);
-        Assertions.assertEquals("POJO name", resource.fields.get("name"));
+        assertEquals("POJO name", resource.fields.get("name"));
 
         HALLink self = (HALLink) resource.fields.get("self");
-        Assertions.assertEquals("http://self.url", self.getHref());
-        Assertions.assertFalse(self.getTemplated());
+        assertEquals("http://self.url", self.getHref());
+        assertFalse(self.getTemplated());
 
         HALLink other = (HALLink) resource.fields.get("otherlink");
-        Assertions.assertEquals("http://other.link.url", other.getHref());
+        assertEquals("http://other.link.url", other.getHref());
 
         HALLink curie2 = (HALLink) resource.fields.get("link2");
-        Assertions.assertEquals("/link2.url", curie2.getHref());
-        Assertions.assertEquals(true, curie2.getTemplated());
+        assertEquals("/link2.url", curie2.getHref());
+        assertEquals(true, curie2.getTemplated());
 
         HALLink curie3 = (HALLink) resource.fields.get("link3");
-        Assertions.assertEquals("http://link3.url{?id}", curie3.getHref());
-        Assertions.assertEquals(true, curie3.getTemplated());
+        assertEquals("http://link3.url{?id}", curie3.getHref());
+        assertEquals(true, curie3.getTemplated());
 
         HALLink curie4 = (HALLink) resource.fields.get("link4");
-        Assertions.assertNull(curie4);
+        assertNull(curie4);
 
-        Assertions.assertEquals("the more you know", resource.fields.get("extras"));
+        assertEquals("the more you know", resource.fields.get("extras"));
     }
 
     @Test
@@ -325,8 +328,8 @@ public class HALBeanDeserializerMethodAnnIT {
         TestCuriesResource resource = om.readValue(json, TestCuriesResource.class);
 
         HALLink link2 = (HALLink) resource.fields.get("link2");
-        Assertions.assertEquals("http://link2.url", link2.getHref());
-        Assertions.assertEquals(true, link2.getTemplated());
+        assertEquals("http://link2.url", link2.getHref());
+        assertEquals(true, link2.getTemplated());
     }
 
 

--- a/src/test/java/io/openapitoools/jackson/dataformat/hal/deser/ReservedPropertyTest.java
+++ b/src/test/java/io/openapitoools/jackson/dataformat/hal/deser/ReservedPropertyTest.java
@@ -1,11 +1,12 @@
 package io.openapitoools.jackson.dataformat.hal.deser;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import java.lang.reflect.Field;
 
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import com.fasterxml.jackson.databind.introspect.AnnotatedField;
@@ -26,7 +27,7 @@ public class ReservedPropertyTest {
 
         String alternateName = ReservedProperty.LINKS.alternateName(bpd,cm );
 
-        Assertions.assertEquals("orig-name", alternateName);
+        assertEquals("orig-name", alternateName);
     }
 
     @Test
@@ -39,7 +40,7 @@ public class ReservedPropertyTest {
 
         String alternateName = ReservedProperty.LINKS.alternateName(bpd, cm);
 
-        Assertions.assertEquals("orig-name", alternateName);
+        assertEquals("orig-name", alternateName);
     }
 
     @Test
@@ -56,7 +57,7 @@ public class ReservedPropertyTest {
 
         String alternateName = ReservedProperty.LINKS.alternateName(bpd, cm);
 
-        Assertions.assertTrue(alternateName.matches(".+:orig-name"));
+        assertTrue(alternateName.matches(".+:orig-name"));
     }
 
     @Test
@@ -73,7 +74,7 @@ public class ReservedPropertyTest {
 
         String alternateName = ReservedProperty.LINKS.alternateName(bpd, cm);
 
-        Assertions.assertTrue(alternateName.matches(".+:alternate-name"));
+        assertTrue(alternateName.matches(".+:alternate-name"));
     }
 
     static class POJO {

--- a/src/test/java/io/openapitoools/jackson/dataformat/hal/deser/ReservedPropertyTest.java
+++ b/src/test/java/io/openapitoools/jackson/dataformat/hal/deser/ReservedPropertyTest.java
@@ -1,18 +1,20 @@
 package io.openapitoools.jackson.dataformat.hal.deser;
 
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.lang.reflect.Field;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
 import com.fasterxml.jackson.databind.introspect.AnnotatedField;
 import com.fasterxml.jackson.databind.introspect.AnnotationMap;
 import com.fasterxml.jackson.databind.introspect.BeanPropertyDefinition;
+
 import io.openapitools.jackson.dataformat.hal.annotation.Link;
 import io.openapitools.jackson.dataformat.hal.deser.CurieMap;
 import io.openapitools.jackson.dataformat.hal.deser.ReservedProperty;
-import java.lang.reflect.Field;
-import org.junit.Test;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-import static org.mockito.Mockito.mock;
-import static org.mockito.Mockito.when;
 
 public class ReservedPropertyTest {
 
@@ -24,7 +26,7 @@ public class ReservedPropertyTest {
 
         String alternateName = ReservedProperty.LINKS.alternateName(bpd,cm );
 
-        assertEquals("orig-name", alternateName);
+        Assertions.assertEquals("orig-name", alternateName);
     }
 
     @Test
@@ -37,7 +39,7 @@ public class ReservedPropertyTest {
 
         String alternateName = ReservedProperty.LINKS.alternateName(bpd, cm);
 
-        assertEquals("orig-name", alternateName);
+        Assertions.assertEquals("orig-name", alternateName);
     }
 
     @Test
@@ -54,7 +56,7 @@ public class ReservedPropertyTest {
 
         String alternateName = ReservedProperty.LINKS.alternateName(bpd, cm);
 
-        assertTrue(alternateName.matches(".+:orig-name"));
+        Assertions.assertTrue(alternateName.matches(".+:orig-name"));
     }
 
     @Test
@@ -71,7 +73,7 @@ public class ReservedPropertyTest {
 
         String alternateName = ReservedProperty.LINKS.alternateName(bpd, cm);
 
-        assertTrue(alternateName.matches(".+:alternate-name"));
+        Assertions.assertTrue(alternateName.matches(".+:alternate-name"));
     }
 
     static class POJO {

--- a/src/test/java/io/openapitoools/jackson/dataformat/hal/ser/HALBeanSerializerIT.java
+++ b/src/test/java/io/openapitoools/jackson/dataformat/hal/ser/HALBeanSerializerIT.java
@@ -6,14 +6,17 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
 import com.fasterxml.jackson.databind.ObjectMapper;
+
 import io.openapitools.jackson.dataformat.hal.HALLink;
 import io.openapitools.jackson.dataformat.hal.HALMapper;
 import io.openapitools.jackson.dataformat.hal.annotation.EmbeddedResource;
 import io.openapitools.jackson.dataformat.hal.annotation.Link;
 import io.openapitools.jackson.dataformat.hal.annotation.Resource;
-import org.junit.Test;
-import static org.junit.Assert.assertEquals;
+
 
 public class HALBeanSerializerIT {
 
@@ -23,7 +26,7 @@ public class HALBeanSerializerIT {
     public void testSerialization() throws Exception {
         TopResource res1 = new TopResource();
         String json = om.writeValueAsString(res1);
-        assertEquals("{"
+        Assertions.assertEquals("{"
                 + "\"_links\":{"
                 + "\"child\":[{\"href\":\"/top/1/child/1\"},{\"href\":\"/top/1/child/2\"}],"
                 + "\"empty:list\":[],"

--- a/src/test/java/io/openapitoools/jackson/dataformat/hal/ser/HALBeanSerializerIT.java
+++ b/src/test/java/io/openapitoools/jackson/dataformat/hal/ser/HALBeanSerializerIT.java
@@ -1,12 +1,12 @@
 package io.openapitoools.jackson.dataformat.hal.ser;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.net.URI;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
@@ -26,7 +26,7 @@ public class HALBeanSerializerIT {
     public void testSerialization() throws Exception {
         TopResource res1 = new TopResource();
         String json = om.writeValueAsString(res1);
-        Assertions.assertEquals("{"
+        assertEquals("{"
                 + "\"_links\":{"
                 + "\"child\":[{\"href\":\"/top/1/child/1\"},{\"href\":\"/top/1/child/2\"}],"
                 + "\"empty:list\":[],"

--- a/src/test/java/io/openapitoools/jackson/dataformat/hal/ser/HALBeanSerializerMethodAnnIT.java
+++ b/src/test/java/io/openapitoools/jackson/dataformat/hal/ser/HALBeanSerializerMethodAnnIT.java
@@ -1,7 +1,15 @@
 package io.openapitoools.jackson.dataformat.hal.ser;
 
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+
 import io.openapitools.jackson.dataformat.hal.HALLink;
 import io.openapitools.jackson.dataformat.hal.HALMapper;
 import io.openapitools.jackson.dataformat.hal.annotation.Curie;
@@ -9,16 +17,6 @@ import io.openapitools.jackson.dataformat.hal.annotation.Curies;
 import io.openapitools.jackson.dataformat.hal.annotation.EmbeddedResource;
 import io.openapitools.jackson.dataformat.hal.annotation.Link;
 import io.openapitools.jackson.dataformat.hal.annotation.Resource;
-import org.junit.Test;
-
-import java.io.IOException;
-import java.util.HashMap;
-import java.util.Map;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertNull;
 
 /**
  * Verify that HAL annotations can be used on methods as well as fields.
@@ -43,37 +41,37 @@ public class HALBeanSerializerMethodAnnIT {
         JsonNode jsonNode = new ObjectMapper().readTree(json);
 
         JsonNode links = jsonNode.path("_links");
-        assertFalse(links.isMissingNode());
-        assertEquals(6, links.size());
+        Assertions.assertFalse(links.isMissingNode());
+        Assertions.assertEquals(6, links.size());
 
         JsonNode curies = links.get("curies");
-        assertFalse(curies.isMissingNode());
-        assertEquals(3, curies.size());
+        Assertions.assertFalse(curies.isMissingNode());
+        Assertions.assertEquals(3, curies.size());
 
         JsonNode relative2UsingCurie = links.get("cur1:relative2");
-        assertFalse(relative2UsingCurie.isMissingNode());
-        assertEquals("http://other.link.url2", relative2UsingCurie.get("href").asText());
-        assertEquals(false, relative2UsingCurie.get("templated").asBoolean());
+        Assertions.assertFalse(relative2UsingCurie.isMissingNode());
+        Assertions.assertEquals("http://other.link.url2", relative2UsingCurie.get("href").asText());
+        Assertions.assertEquals(false, relative2UsingCurie.get("templated").asBoolean());
 
         JsonNode relative3UsingCurie = links.get("cur2:relative3");
-        assertFalse(relative3UsingCurie.isMissingNode());
-        assertEquals("http://other.link.url3{?id}", relative3UsingCurie.get("href").asText());
-        assertEquals(true, relative3UsingCurie.get("templated").asBoolean());
-        
-       
+        Assertions.assertFalse(relative3UsingCurie.isMissingNode());
+        Assertions.assertEquals("http://other.link.url3{?id}", relative3UsingCurie.get("href").asText());
+        Assertions.assertEquals(true, relative3UsingCurie.get("templated").asBoolean());
+
+
         JsonNode relative4UsingCurie = links.get("cur3:relative4");
-        assertFalse(relative4UsingCurie.isMissingNode());
-        assertEquals("/other.link.url4{?id}", relative4UsingCurie.get("href").asText());
-        assertEquals(true, relative4UsingCurie.get("templated").asBoolean());
+        Assertions.assertFalse(relative4UsingCurie.isMissingNode());
+        Assertions.assertEquals("/other.link.url4{?id}", relative4UsingCurie.get("href").asText());
+        Assertions.assertEquals(true, relative4UsingCurie.get("templated").asBoolean());
 
         JsonNode curie4 = curies.get("cur4-not-used");
-        assertNull(curie4);
+        Assertions.assertNull(curie4);
 
         JsonNode embedded = jsonNode.path("_embedded");
-        assertFalse(embedded.isMissingNode());
-        assertEquals(1, embedded.size());
+        Assertions.assertFalse(embedded.isMissingNode());
+        Assertions.assertEquals(1, embedded.size());
 
-        assertEquals("POJO name", jsonNode.get("name").asText());
+        Assertions.assertEquals("POJO name", jsonNode.get("name").asText());
     }
 
     @Test
@@ -90,21 +88,21 @@ public class HALBeanSerializerMethodAnnIT {
         JsonNode jsonNode = new ObjectMapper().readTree(json);
 
         JsonNode links = jsonNode.path("_links");
-        assertFalse(links.isMissingNode());
-        assertEquals(2, links.size());
+        Assertions.assertFalse(links.isMissingNode());
+        Assertions.assertEquals(2, links.size());
 
         JsonNode curies = links.get("curies");
-        assertFalse(curies.isMissingNode());
+        Assertions.assertFalse(curies.isMissingNode());
         // prune empty which means only 1 exixts
-        assertEquals(1, curies.size());
-        
+        Assertions.assertEquals(1, curies.size());
+
         JsonNode curie1 = curies.get(0);
-        assertNotNull(curie1);
-        assertEquals("cur1", curie1.get("name").asText());
-        assertEquals("http://docs.my.site/{rel}", curie1.get("href").asText());
-        
+        Assertions.assertNotNull(curie1);
+        Assertions.assertEquals("cur1", curie1.get("name").asText());
+        Assertions.assertEquals("http://docs.my.site/{rel}", curie1.get("href").asText());
+
         JsonNode relative1UsingCurie = links.get("cur1:relative1");
-        assertFalse(relative1UsingCurie.isMissingNode());
+        Assertions.assertFalse(relative1UsingCurie.isMissingNode());
     }
 
     @Resource
@@ -144,7 +142,7 @@ public class HALBeanSerializerMethodAnnIT {
         public HALLink getRelatedLink3() {
             return (HALLink) fields.get("friend3");
         }
-    
+
         public HALLink getRelatedLink4() {
             return (HALLink) fields.get("friend4");
         }
@@ -158,12 +156,12 @@ public class HALBeanSerializerMethodAnnIT {
         public void setRelatedLink2(HALLink link) {
             fields.put("friend2", link);
         }
- 
+
         @Link(value = "relative3", curie = "cur2")
         public void setRelatedLink3(HALLink link) {
             fields.put("friend3", link);
         }
- 
+
         @Link(value = "relative4", curie = "cur3")
         public void setRelatedLink4(HALLink link) {
             fields.put("friend4", link);

--- a/src/test/java/io/openapitoools/jackson/dataformat/hal/ser/HALBeanSerializerMethodAnnIT.java
+++ b/src/test/java/io/openapitoools/jackson/dataformat/hal/ser/HALBeanSerializerMethodAnnIT.java
@@ -1,10 +1,14 @@
 package io.openapitoools.jackson.dataformat.hal.ser;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
 import java.io.IOException;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import com.fasterxml.jackson.databind.JsonNode;
@@ -41,37 +45,37 @@ public class HALBeanSerializerMethodAnnIT {
         JsonNode jsonNode = new ObjectMapper().readTree(json);
 
         JsonNode links = jsonNode.path("_links");
-        Assertions.assertFalse(links.isMissingNode());
-        Assertions.assertEquals(6, links.size());
+        assertFalse(links.isMissingNode());
+        assertEquals(6, links.size());
 
         JsonNode curies = links.get("curies");
-        Assertions.assertFalse(curies.isMissingNode());
-        Assertions.assertEquals(3, curies.size());
+        assertFalse(curies.isMissingNode());
+        assertEquals(3, curies.size());
 
         JsonNode relative2UsingCurie = links.get("cur1:relative2");
-        Assertions.assertFalse(relative2UsingCurie.isMissingNode());
-        Assertions.assertEquals("http://other.link.url2", relative2UsingCurie.get("href").asText());
-        Assertions.assertEquals(false, relative2UsingCurie.get("templated").asBoolean());
+        assertFalse(relative2UsingCurie.isMissingNode());
+        assertEquals("http://other.link.url2", relative2UsingCurie.get("href").asText());
+        assertEquals(false, relative2UsingCurie.get("templated").asBoolean());
 
         JsonNode relative3UsingCurie = links.get("cur2:relative3");
-        Assertions.assertFalse(relative3UsingCurie.isMissingNode());
-        Assertions.assertEquals("http://other.link.url3{?id}", relative3UsingCurie.get("href").asText());
-        Assertions.assertEquals(true, relative3UsingCurie.get("templated").asBoolean());
+        assertFalse(relative3UsingCurie.isMissingNode());
+        assertEquals("http://other.link.url3{?id}", relative3UsingCurie.get("href").asText());
+        assertEquals(true, relative3UsingCurie.get("templated").asBoolean());
 
 
         JsonNode relative4UsingCurie = links.get("cur3:relative4");
-        Assertions.assertFalse(relative4UsingCurie.isMissingNode());
-        Assertions.assertEquals("/other.link.url4{?id}", relative4UsingCurie.get("href").asText());
-        Assertions.assertEquals(true, relative4UsingCurie.get("templated").asBoolean());
+        assertFalse(relative4UsingCurie.isMissingNode());
+        assertEquals("/other.link.url4{?id}", relative4UsingCurie.get("href").asText());
+        assertEquals(true, relative4UsingCurie.get("templated").asBoolean());
 
         JsonNode curie4 = curies.get("cur4-not-used");
-        Assertions.assertNull(curie4);
+        assertNull(curie4);
 
         JsonNode embedded = jsonNode.path("_embedded");
-        Assertions.assertFalse(embedded.isMissingNode());
-        Assertions.assertEquals(1, embedded.size());
+        assertFalse(embedded.isMissingNode());
+        assertEquals(1, embedded.size());
 
-        Assertions.assertEquals("POJO name", jsonNode.get("name").asText());
+        assertEquals("POJO name", jsonNode.get("name").asText());
     }
 
     @Test
@@ -88,21 +92,21 @@ public class HALBeanSerializerMethodAnnIT {
         JsonNode jsonNode = new ObjectMapper().readTree(json);
 
         JsonNode links = jsonNode.path("_links");
-        Assertions.assertFalse(links.isMissingNode());
-        Assertions.assertEquals(2, links.size());
+        assertFalse(links.isMissingNode());
+        assertEquals(2, links.size());
 
         JsonNode curies = links.get("curies");
-        Assertions.assertFalse(curies.isMissingNode());
+        assertFalse(curies.isMissingNode());
         // prune empty which means only 1 exixts
-        Assertions.assertEquals(1, curies.size());
+        assertEquals(1, curies.size());
 
         JsonNode curie1 = curies.get(0);
-        Assertions.assertNotNull(curie1);
-        Assertions.assertEquals("cur1", curie1.get("name").asText());
-        Assertions.assertEquals("http://docs.my.site/{rel}", curie1.get("href").asText());
+        assertNotNull(curie1);
+        assertEquals("cur1", curie1.get("name").asText());
+        assertEquals("http://docs.my.site/{rel}", curie1.get("href").asText());
 
         JsonNode relative1UsingCurie = links.get("cur1:relative1");
-        Assertions.assertFalse(relative1UsingCurie.isMissingNode());
+        assertFalse(relative1UsingCurie.isMissingNode());
     }
 
     @Resource

--- a/src/test/java/io/openapitoools/jackson/dataformat/hal/ser/HALBeanSerializerPolymorphicWithExistingFieldIT.java
+++ b/src/test/java/io/openapitoools/jackson/dataformat/hal/ser/HALBeanSerializerPolymorphicWithExistingFieldIT.java
@@ -1,22 +1,24 @@
 package io.openapitoools.jackson.dataformat.hal.ser;
 
-import static org.junit.Assert.assertEquals;
+import java.net.URI;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
 import com.fasterxml.jackson.annotation.JsonTypeInfo.As;
 import com.fasterxml.jackson.annotation.JsonTypeInfo.Id;
 import com.fasterxml.jackson.databind.ObjectMapper;
+
 import io.openapitools.jackson.dataformat.hal.HALLink;
 import io.openapitools.jackson.dataformat.hal.HALMapper;
 import io.openapitools.jackson.dataformat.hal.annotation.EmbeddedResource;
 import io.openapitools.jackson.dataformat.hal.annotation.Link;
 import io.openapitools.jackson.dataformat.hal.annotation.Resource;
-import java.net.URI;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.List;
-import org.junit.Test;
 
 public class HALBeanSerializerPolymorphicWithExistingFieldIT {
 
@@ -26,8 +28,6 @@ public class HALBeanSerializerPolymorphicWithExistingFieldIT {
   public void testSerializationForResourceWithEmbeddableList() throws Exception {
     @Resource
     class TopResource {
-
-      public String id = "1";
 
       @Link public HALLink self = new HALLink.Builder(URI.create("/top/1")).build();
 
@@ -44,7 +44,7 @@ public class HALBeanSerializerPolymorphicWithExistingFieldIT {
 
     TopResource resource = new TopResource();
     String json = om.writeValueAsString(resource);
-    assertEquals(
+    Assertions.assertEquals(
         "{"
             + "\"_links\":{"
             + "\"child\":[{\"href\":\"/top/1/child/1\"},{\"href\":\"/top/1/child/2\"}],"
@@ -63,17 +63,12 @@ public class HALBeanSerializerPolymorphicWithExistingFieldIT {
   public void testSerializationForResourceWithList() throws Exception {
     @Resource
     class TopResourceWithoutEmbedded {
-      public String id = "1";
-
       @Link public HALLink self = new HALLink.Builder(URI.create("/top/1")).build();
-
-      public Collection<ChildResource> children =
-          Arrays.asList(new ChildResource("1"), new OtherChildResource("2", "Max"));
     }
 
     TopResourceWithoutEmbedded resource = new TopResourceWithoutEmbedded();
     String json = om.writeValueAsString(resource);
-    assertEquals(
+    Assertions.assertEquals(
         "{"
             + "\"_links\":{"
             + "\"self\":{\"href\":\"/top/1\"}"
@@ -90,8 +85,6 @@ public class HALBeanSerializerPolymorphicWithExistingFieldIT {
   public void testSerializationForResourceEmbedded() throws Exception {
     @Resource
     class SimpleTopResourceEmbedded {
-      public String id = "1";
-
       @Link public HALLink self = new HALLink.Builder(URI.create("/top/1")).build();
 
       @EmbeddedResource public ChildResource child = new ChildResource("1");
@@ -99,7 +92,7 @@ public class HALBeanSerializerPolymorphicWithExistingFieldIT {
 
     SimpleTopResourceEmbedded resource = new SimpleTopResourceEmbedded();
     String json = om.writeValueAsString(resource);
-    assertEquals(
+    Assertions.assertEquals(
         "{"
             + "\"_links\":{"
             + "\"self\":{\"href\":\"/top/1\"}"
@@ -115,16 +108,12 @@ public class HALBeanSerializerPolymorphicWithExistingFieldIT {
   public void testSerializationForResource() throws Exception {
     @Resource
     class SimpleTopResource {
-      public String id = "1";
-
       @Link public HALLink self = new HALLink.Builder(URI.create("/top/1")).build();
-
-      public ChildResource child = new ChildResource("1");
     }
 
     SimpleTopResource resource = new SimpleTopResource();
     String json = om.writeValueAsString(resource);
-    assertEquals(
+    Assertions.assertEquals(
         "{"
             + "\"_links\":{"
             + "\"self\":{\"href\":\"/top/1\"}"
@@ -140,7 +129,7 @@ public class HALBeanSerializerPolymorphicWithExistingFieldIT {
   public void testSerializationForAnnotatedPolymorphicObject() throws Exception {
     ChildResource resource = new ChildResource("1");
     String json = om.writeValueAsString(resource);
-    assertEquals(
+    Assertions.assertEquals(
         "{"
             + "\"_links\":{"
             + "\"self\":{\"href\":\"/top/1/child/1\"}"
@@ -154,7 +143,7 @@ public class HALBeanSerializerPolymorphicWithExistingFieldIT {
   public void testSerializationForNotAnnotatedPolymorphicObject() throws Exception {
     ChildResource resource = new OtherChildResource("1", "Max");
     String json = om.writeValueAsString(resource);
-    assertEquals(
+    Assertions.assertEquals(
         "{"
             + "\"_links\":{"
             + "\"self\":{\"href\":\"/top/1/child/1\"}"

--- a/src/test/java/io/openapitoools/jackson/dataformat/hal/ser/HALBeanSerializerPolymorphicWithExistingFieldIT.java
+++ b/src/test/java/io/openapitoools/jackson/dataformat/hal/ser/HALBeanSerializerPolymorphicWithExistingFieldIT.java
@@ -26,21 +26,19 @@ public class HALBeanSerializerPolymorphicWithExistingFieldIT {
 
   @Test
   public void testSerializationForResourceWithEmbeddableList() throws Exception {
-    @Resource
-    class TopResource {
-
-      @Link public HALLink self = new HALLink.Builder(URI.create("/top/1")).build();
-
-      @Link("child")
-      public List<HALLink> childResourcesLink =
-          Arrays.asList(
-              new HALLink.Builder(URI.create("/top/1/child/1")).build(),
-              new HALLink.Builder(URI.create("/top/1/child/2")).build());
-
-      @EmbeddedResource("child")
-      public Collection<ChildResource> children =
-          Arrays.asList(new ChildResource("1"), new OtherChildResource("2", "Max"));
-    }
+      @Resource
+      @SuppressWarnings("unused")
+      class TopResource {
+	  public String id = "1";
+	  @Link
+	  public HALLink self = new HALLink.Builder(URI.create("/top/1")).build();
+	  @Link("child")
+	  public List<HALLink> childResourcesLink = Arrays.asList(
+		  new HALLink.Builder(URI.create("/top/1/child/1")).build(),
+		  new HALLink.Builder(URI.create("/top/1/child/2")).build());
+	  @EmbeddedResource("child")
+	  public Collection<ChildResource> children = Arrays.asList(new ChildResource("1"), new OtherChildResource("2", "Max"));
+      }
 
     TopResource resource = new TopResource();
     String json = om.writeValueAsString(resource);
@@ -61,10 +59,15 @@ public class HALBeanSerializerPolymorphicWithExistingFieldIT {
 
   @Test
   public void testSerializationForResourceWithList() throws Exception {
-    @Resource
-    class TopResourceWithoutEmbedded {
-      @Link public HALLink self = new HALLink.Builder(URI.create("/top/1")).build();
-    }
+      @Resource
+      @SuppressWarnings("unused")
+      class TopResourceWithoutEmbedded {
+	  public String id = "1";
+	  @Link
+	  public HALLink self = new HALLink.Builder(URI.create("/top/1")).build();
+	  public Collection<ChildResource> children = Arrays.asList(new ChildResource("1"),
+		  new OtherChildResource("2", "Max"));
+      }
 
     TopResourceWithoutEmbedded resource = new TopResourceWithoutEmbedded();
     String json = om.writeValueAsString(resource);
@@ -83,12 +86,15 @@ public class HALBeanSerializerPolymorphicWithExistingFieldIT {
 
   @Test
   public void testSerializationForResourceEmbedded() throws Exception {
-    @Resource
-    class SimpleTopResourceEmbedded {
-      @Link public HALLink self = new HALLink.Builder(URI.create("/top/1")).build();
-
-      @EmbeddedResource public ChildResource child = new ChildResource("1");
-    }
+      @Resource
+      @SuppressWarnings("unused")
+      class SimpleTopResourceEmbedded {
+	  public String id = "1";
+	  @Link
+	  public HALLink self = new HALLink.Builder(URI.create("/top/1")).build();
+	  @EmbeddedResource
+	  public ChildResource child = new ChildResource("1");
+      }
 
     SimpleTopResourceEmbedded resource = new SimpleTopResourceEmbedded();
     String json = om.writeValueAsString(resource);
@@ -107,8 +113,11 @@ public class HALBeanSerializerPolymorphicWithExistingFieldIT {
   @Test
   public void testSerializationForResource() throws Exception {
     @Resource
+    @SuppressWarnings("unused")
     class SimpleTopResource {
-      @Link public HALLink self = new HALLink.Builder(URI.create("/top/1")).build();
+	public String id = "1";
+	@Link public HALLink self = new HALLink.Builder(URI.create("/top/1")).build();
+	public ChildResource child = new ChildResource("1");
     }
 
     SimpleTopResource resource = new SimpleTopResource();

--- a/src/test/java/io/openapitoools/jackson/dataformat/hal/ser/HALBeanSerializerPolymorphicWithExistingFieldIT.java
+++ b/src/test/java/io/openapitoools/jackson/dataformat/hal/ser/HALBeanSerializerPolymorphicWithExistingFieldIT.java
@@ -1,11 +1,12 @@
 package io.openapitoools.jackson.dataformat.hal.ser;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
 import java.net.URI;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import com.fasterxml.jackson.annotation.JsonSubTypes;
@@ -42,7 +43,7 @@ public class HALBeanSerializerPolymorphicWithExistingFieldIT {
 
     TopResource resource = new TopResource();
     String json = om.writeValueAsString(resource);
-    Assertions.assertEquals(
+    assertEquals(
         "{"
             + "\"_links\":{"
             + "\"child\":[{\"href\":\"/top/1/child/1\"},{\"href\":\"/top/1/child/2\"}],"
@@ -71,7 +72,7 @@ public class HALBeanSerializerPolymorphicWithExistingFieldIT {
 
     TopResourceWithoutEmbedded resource = new TopResourceWithoutEmbedded();
     String json = om.writeValueAsString(resource);
-    Assertions.assertEquals(
+    assertEquals(
         "{"
             + "\"_links\":{"
             + "\"self\":{\"href\":\"/top/1\"}"
@@ -98,7 +99,7 @@ public class HALBeanSerializerPolymorphicWithExistingFieldIT {
 
     SimpleTopResourceEmbedded resource = new SimpleTopResourceEmbedded();
     String json = om.writeValueAsString(resource);
-    Assertions.assertEquals(
+    assertEquals(
         "{"
             + "\"_links\":{"
             + "\"self\":{\"href\":\"/top/1\"}"
@@ -122,7 +123,7 @@ public class HALBeanSerializerPolymorphicWithExistingFieldIT {
 
     SimpleTopResource resource = new SimpleTopResource();
     String json = om.writeValueAsString(resource);
-    Assertions.assertEquals(
+    assertEquals(
         "{"
             + "\"_links\":{"
             + "\"self\":{\"href\":\"/top/1\"}"
@@ -138,7 +139,7 @@ public class HALBeanSerializerPolymorphicWithExistingFieldIT {
   public void testSerializationForAnnotatedPolymorphicObject() throws Exception {
     ChildResource resource = new ChildResource("1");
     String json = om.writeValueAsString(resource);
-    Assertions.assertEquals(
+    assertEquals(
         "{"
             + "\"_links\":{"
             + "\"self\":{\"href\":\"/top/1/child/1\"}"
@@ -152,7 +153,7 @@ public class HALBeanSerializerPolymorphicWithExistingFieldIT {
   public void testSerializationForNotAnnotatedPolymorphicObject() throws Exception {
     ChildResource resource = new OtherChildResource("1", "Max");
     String json = om.writeValueAsString(resource);
-    Assertions.assertEquals(
+    assertEquals(
         "{"
             + "\"_links\":{"
             + "\"self\":{\"href\":\"/top/1/child/1\"}"

--- a/src/test/java/io/openapitoools/jackson/dataformat/hal/ser/HALBeanSerializerPolymorphicWithPropertyIT.java
+++ b/src/test/java/io/openapitoools/jackson/dataformat/hal/ser/HALBeanSerializerPolymorphicWithPropertyIT.java
@@ -1,11 +1,12 @@
 package io.openapitoools.jackson.dataformat.hal.ser;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
 import java.net.URI;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 
-import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import com.fasterxml.jackson.annotation.JsonSubTypes;
@@ -43,7 +44,7 @@ public class HALBeanSerializerPolymorphicWithPropertyIT {
 
     TopResource resource = new TopResource();
     String json = om.writeValueAsString(resource);
-    Assertions.assertEquals(
+    assertEquals(
         "{"
             + "\"_links\":{"
             + "\"child\":[{\"href\":\"/top/1/child/1\"},{\"href\":\"/top/1/child/2\"}],"
@@ -70,7 +71,7 @@ public class HALBeanSerializerPolymorphicWithPropertyIT {
 
     TopResourceWithoutEmbedded resource = new TopResourceWithoutEmbedded();
     String json = om.writeValueAsString(resource);
-    Assertions.assertEquals(
+    assertEquals(
         "{"
             + "\"_links\":{"
             + "\"self\":{\"href\":\"/top/1\"}"
@@ -97,7 +98,7 @@ public class HALBeanSerializerPolymorphicWithPropertyIT {
 
     SimpleTopResourceEmbedded resource = new SimpleTopResourceEmbedded();
     String json = om.writeValueAsString(resource);
-    Assertions.assertEquals(
+    assertEquals(
         "{"
             + "\"_links\":{"
             + "\"self\":{\"href\":\"/top/1\"}"
@@ -122,7 +123,7 @@ public class HALBeanSerializerPolymorphicWithPropertyIT {
 
     SimpleTopResource resource = new SimpleTopResource();
     String json = om.writeValueAsString(resource);
-    Assertions.assertEquals(
+    assertEquals(
         "{"
             + "\"_links\":{"
             + "\"self\":{\"href\":\"/top/1\"}"
@@ -138,7 +139,7 @@ public class HALBeanSerializerPolymorphicWithPropertyIT {
   public void testSerializationForAnnotatedPolymorphicObject() throws Exception {
     ChildResource resource = new ChildResource("1");
     String json = om.writeValueAsString(resource);
-    Assertions.assertEquals(
+    assertEquals(
         "{"
             + "\"@type\":\"ChildResource\","
             + "\"_links\":{"
@@ -152,7 +153,7 @@ public class HALBeanSerializerPolymorphicWithPropertyIT {
   public void testSerializationForNotAnnotatedPolymorphicObject() throws Exception {
     ChildResource resource = new OtherChildResource("1", "Max");
     String json = om.writeValueAsString(resource);
-    Assertions.assertEquals(
+    assertEquals(
         "{"
             + "\"@type\":\"OtherChildResource\","
             + "\"_links\":{"

--- a/src/test/java/io/openapitoools/jackson/dataformat/hal/ser/HALBeanSerializerPolymorphicWithPropertyIT.java
+++ b/src/test/java/io/openapitoools/jackson/dataformat/hal/ser/HALBeanSerializerPolymorphicWithPropertyIT.java
@@ -27,21 +27,19 @@ public class HALBeanSerializerPolymorphicWithPropertyIT {
 
   @Test
   public void testSerializationForResourceWithEmbeddableList() throws Exception {
-    @Resource
-    class TopResource {
-
-      @Link public HALLink self = new HALLink.Builder(URI.create("/top/1")).build();
-
-      @Link("child")
-      public List<HALLink> childResourcesLink =
-          Arrays.asList(
-              new HALLink.Builder(URI.create("/top/1/child/1")).build(),
-              new HALLink.Builder(URI.create("/top/1/child/2")).build());
-
-      @EmbeddedResource("child")
-      public Collection<ChildResource> children =
-          Arrays.asList(new ChildResource("1"), new OtherChildResource("2", "Max"));
-    }
+      @Resource
+      @SuppressWarnings("unused")
+      class TopResource {
+	  public String id = "1";
+	  @Link
+	  public HALLink self = new HALLink.Builder(URI.create("/top/1")).build();
+	  @Link("child")
+	  public List<HALLink> childResourcesLink = Arrays.asList(
+		  new HALLink.Builder(URI.create("/top/1/child/1")).build(),
+		  new HALLink.Builder(URI.create("/top/1/child/2")).build());
+	  @EmbeddedResource("child")
+	  public Collection<ChildResource> children = Arrays.asList(new ChildResource("1"), new OtherChildResource("2", "Max"));
+      }
 
     TopResource resource = new TopResource();
     String json = om.writeValueAsString(resource);
@@ -63,8 +61,11 @@ public class HALBeanSerializerPolymorphicWithPropertyIT {
   @Test
   public void testSerializationForResourceWithList() throws Exception {
     @Resource
+    @SuppressWarnings("unused")
     class TopResourceWithoutEmbedded {
-      @Link public HALLink self = new HALLink.Builder(URI.create("/top/1")).build();
+	public String id = "1";
+	@Link public HALLink self = new HALLink.Builder(URI.create("/top/1")).build();
+	 public Collection<ChildResource> children = Arrays.asList(new ChildResource("1"), new OtherChildResource("2", "Max"));
     }
 
     TopResourceWithoutEmbedded resource = new TopResourceWithoutEmbedded();
@@ -85,11 +86,13 @@ public class HALBeanSerializerPolymorphicWithPropertyIT {
   @Test
   public void testSerializationForResourceEmbedded() throws Exception {
     @Resource
+    @SuppressWarnings("unused")
     class SimpleTopResourceEmbedded {
-      @Link public HALLink self = new HALLink.Builder(URI.create("/top/1")).build();
-
-      @EmbeddedResource
-      public ChildResource child = new ChildResource("1");
+	public String id = "1";
+	@Link
+	public HALLink self = new HALLink.Builder(URI.create("/top/1")).build();
+	@EmbeddedResource
+	public ChildResource child = new ChildResource("1");
     }
 
     SimpleTopResourceEmbedded resource = new SimpleTopResourceEmbedded();
@@ -109,8 +112,12 @@ public class HALBeanSerializerPolymorphicWithPropertyIT {
   @Test
   public void testSerializationForResource() throws Exception {
     @Resource
+    @SuppressWarnings("unused")
     class SimpleTopResource {
-      @Link public HALLink self = new HALLink.Builder(URI.create("/top/1")).build();
+	public String id = "1";
+	@Link
+	public HALLink self = new HALLink.Builder(URI.create("/top/1")).build();
+	public ChildResource child = new ChildResource("1");
     }
 
     SimpleTopResource resource = new SimpleTopResource();

--- a/src/test/java/io/openapitoools/jackson/dataformat/hal/ser/HALBeanSerializerPolymorphicWithPropertyIT.java
+++ b/src/test/java/io/openapitoools/jackson/dataformat/hal/ser/HALBeanSerializerPolymorphicWithPropertyIT.java
@@ -1,6 +1,12 @@
 package io.openapitoools.jackson.dataformat.hal.ser;
 
-import static org.junit.Assert.assertEquals;
+import java.net.URI;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
 
 import com.fasterxml.jackson.annotation.JsonSubTypes;
 import com.fasterxml.jackson.annotation.JsonTypeInfo;
@@ -8,16 +14,12 @@ import com.fasterxml.jackson.annotation.JsonTypeInfo.As;
 import com.fasterxml.jackson.annotation.JsonTypeInfo.Id;
 import com.fasterxml.jackson.annotation.JsonTypeName;
 import com.fasterxml.jackson.databind.ObjectMapper;
+
 import io.openapitools.jackson.dataformat.hal.HALLink;
 import io.openapitools.jackson.dataformat.hal.HALMapper;
 import io.openapitools.jackson.dataformat.hal.annotation.EmbeddedResource;
 import io.openapitools.jackson.dataformat.hal.annotation.Link;
 import io.openapitools.jackson.dataformat.hal.annotation.Resource;
-import java.net.URI;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.List;
-import org.junit.Test;
 
 public class HALBeanSerializerPolymorphicWithPropertyIT {
 
@@ -27,8 +29,6 @@ public class HALBeanSerializerPolymorphicWithPropertyIT {
   public void testSerializationForResourceWithEmbeddableList() throws Exception {
     @Resource
     class TopResource {
-
-      public String id = "1";
 
       @Link public HALLink self = new HALLink.Builder(URI.create("/top/1")).build();
 
@@ -45,7 +45,7 @@ public class HALBeanSerializerPolymorphicWithPropertyIT {
 
     TopResource resource = new TopResource();
     String json = om.writeValueAsString(resource);
-    assertEquals(
+    Assertions.assertEquals(
         "{"
             + "\"_links\":{"
             + "\"child\":[{\"href\":\"/top/1/child/1\"},{\"href\":\"/top/1/child/2\"}],"
@@ -64,17 +64,12 @@ public class HALBeanSerializerPolymorphicWithPropertyIT {
   public void testSerializationForResourceWithList() throws Exception {
     @Resource
     class TopResourceWithoutEmbedded {
-      public String id = "1";
-
       @Link public HALLink self = new HALLink.Builder(URI.create("/top/1")).build();
-
-      public Collection<ChildResource> children =
-          Arrays.asList(new ChildResource("1"), new OtherChildResource("2", "Max"));
     }
 
     TopResourceWithoutEmbedded resource = new TopResourceWithoutEmbedded();
     String json = om.writeValueAsString(resource);
-    assertEquals(
+    Assertions.assertEquals(
         "{"
             + "\"_links\":{"
             + "\"self\":{\"href\":\"/top/1\"}"
@@ -91,8 +86,6 @@ public class HALBeanSerializerPolymorphicWithPropertyIT {
   public void testSerializationForResourceEmbedded() throws Exception {
     @Resource
     class SimpleTopResourceEmbedded {
-      public String id = "1";
-
       @Link public HALLink self = new HALLink.Builder(URI.create("/top/1")).build();
 
       @EmbeddedResource
@@ -101,7 +94,7 @@ public class HALBeanSerializerPolymorphicWithPropertyIT {
 
     SimpleTopResourceEmbedded resource = new SimpleTopResourceEmbedded();
     String json = om.writeValueAsString(resource);
-    assertEquals(
+    Assertions.assertEquals(
         "{"
             + "\"_links\":{"
             + "\"self\":{\"href\":\"/top/1\"}"
@@ -117,16 +110,12 @@ public class HALBeanSerializerPolymorphicWithPropertyIT {
   public void testSerializationForResource() throws Exception {
     @Resource
     class SimpleTopResource {
-      public String id = "1";
-
       @Link public HALLink self = new HALLink.Builder(URI.create("/top/1")).build();
-
-      public ChildResource child = new ChildResource("1");
     }
 
     SimpleTopResource resource = new SimpleTopResource();
     String json = om.writeValueAsString(resource);
-    assertEquals(
+    Assertions.assertEquals(
         "{"
             + "\"_links\":{"
             + "\"self\":{\"href\":\"/top/1\"}"
@@ -142,7 +131,7 @@ public class HALBeanSerializerPolymorphicWithPropertyIT {
   public void testSerializationForAnnotatedPolymorphicObject() throws Exception {
     ChildResource resource = new ChildResource("1");
     String json = om.writeValueAsString(resource);
-    assertEquals(
+    Assertions.assertEquals(
         "{"
             + "\"@type\":\"ChildResource\","
             + "\"_links\":{"
@@ -156,7 +145,7 @@ public class HALBeanSerializerPolymorphicWithPropertyIT {
   public void testSerializationForNotAnnotatedPolymorphicObject() throws Exception {
     ChildResource resource = new OtherChildResource("1", "Max");
     String json = om.writeValueAsString(resource);
-    assertEquals(
+    Assertions.assertEquals(
         "{"
             + "\"@type\":\"OtherChildResource\","
             + "\"_links\":{"

--- a/src/test/java/io/openapitoools/jackson/dataformat/hal/ser/HALBeanSerializerPolymorphicWithPropertyIT.java
+++ b/src/test/java/io/openapitoools/jackson/dataformat/hal/ser/HALBeanSerializerPolymorphicWithPropertyIT.java
@@ -23,174 +23,166 @@ import io.openapitools.jackson.dataformat.hal.annotation.Link;
 import io.openapitools.jackson.dataformat.hal.annotation.Resource;
 
 public class HALBeanSerializerPolymorphicWithPropertyIT {
+    ObjectMapper om = new HALMapper();
 
-  ObjectMapper om = new HALMapper();
+    @Test
+    public void testSerializationForResourceWithEmbeddableList() throws Exception {
+        @Resource
+        @SuppressWarnings("unused")
+        class TopResource {
+            public String id = "1";
+            @Link
+            public HALLink self = new HALLink.Builder(URI.create("/top/1")).build();
+            @Link("child")
+            public List<HALLink> childResourcesLink = Arrays.asList(
+                    new HALLink.Builder(URI.create("/top/1/child/1")).build(),
+                    new HALLink.Builder(URI.create("/top/1/child/2")).build());
+            @EmbeddedResource("child")
+            public Collection<ChildResource> children = Arrays.asList(new ChildResource("1"),
+                    new OtherChildResource("2", "Max"));
+        }
+        TopResource resource = new TopResource();
+        String json = om.writeValueAsString(resource);
+        assertEquals(
+                "{" +
+                    "\"_links\":{" +
+                        "\"child\":[{\"href\":\"/top/1/child/1\"},{\"href\":\"/top/1/child/2\"}]," +
+                        "\"self\":{\"href\":\"/top/1\"}" +
+                    "}," +
+                    "\"_embedded\":{" +
+                        "\"child\":[" +
+                        "{\"@type\":\"ChildResource\",\"_links\":{\"self\":{\"href\":\"/top/1/child/1\"}},\"id\":\"1\"}," +
+                        "{\"@type\":\"OtherChildResource\",\"_links\":{\"self\":{\"href\":\"/top/1/child/2\"}},\"id\":\"2\",\"name\":\"Max\"}]" +
+                    "}," +
+                    "\"id\":\"1\"" +
+                "}", json);
+    }
 
-  @Test
-  public void testSerializationForResourceWithEmbeddableList() throws Exception {
-      @Resource
-      @SuppressWarnings("unused")
-      class TopResource {
-	  public String id = "1";
-	  @Link
-	  public HALLink self = new HALLink.Builder(URI.create("/top/1")).build();
-	  @Link("child")
-	  public List<HALLink> childResourcesLink = Arrays.asList(
-		  new HALLink.Builder(URI.create("/top/1/child/1")).build(),
-		  new HALLink.Builder(URI.create("/top/1/child/2")).build());
-	  @EmbeddedResource("child")
-	  public Collection<ChildResource> children = Arrays.asList(new ChildResource("1"), new OtherChildResource("2", "Max"));
-      }
+    @Test
+    public void testSerializationForResourceWithList() throws Exception {
+        @Resource
+        @SuppressWarnings("unused")
+        class TopResourceWithoutEmbedded {
+            public String id = "1";
+            @Link
+            public HALLink self = new HALLink.Builder(URI.create("/top/1")).build();
+            public Collection<ChildResource> children = Arrays.asList(new ChildResource("1"),
+                    new OtherChildResource("2", "Max"));
+        }
+        TopResourceWithoutEmbedded resource = new TopResourceWithoutEmbedded();
+        String json = om.writeValueAsString(resource);
+        assertEquals(
+                "{" +
+                    "\"_links\":{" +
+                        "\"self\":{\"href\":\"/top/1\"}" +
+                    "}," +
+                    "\"id\":\"1\"," +
+                    "\"children\":[" +
+                    "{\"@type\":\"ChildResource\",\"_links\":{\"self\":{\"href\":\"/top/1/child/1\"}},\"id\":\"1\"}," +
+                    "{\"@type\":\"OtherChildResource\",\"_links\":{\"self\":{\"href\":\"/top/1/child/2\"}},\"id\":\"2\",\"name\":\"Max\"}]"+
+                "}", json);
+    }
 
-    TopResource resource = new TopResource();
-    String json = om.writeValueAsString(resource);
-    assertEquals(
-        "{"
-            + "\"_links\":{"
-            + "\"child\":[{\"href\":\"/top/1/child/1\"},{\"href\":\"/top/1/child/2\"}],"
-            + "\"self\":{\"href\":\"/top/1\"}"
-            + "},"
-            + "\"_embedded\":{"
-            + "\"child\":["
-            + "{\"@type\":\"ChildResource\",\"_links\":{\"self\":{\"href\":\"/top/1/child/1\"}},\"id\":\"1\"},"
-            + "{\"@type\":\"OtherChildResource\",\"_links\":{\"self\":{\"href\":\"/top/1/child/2\"}},\"id\":\"2\",\"name\":\"Max\"}]"
-            + "},"
-            + "\"id\":\"1\"}",
-        json);
-  }
+    @Test
+    public void testSerializationForResourceEmbedded() throws Exception {
+        @Resource
+        @SuppressWarnings("unused")
+        class SimpleTopResourceEmbedded {
+            public String id = "1";
+            @Link
+            public HALLink self = new HALLink.Builder(URI.create("/top/1")).build();
+            @EmbeddedResource
+            public ChildResource child = new ChildResource("1");
+        }
+        SimpleTopResourceEmbedded resource = new SimpleTopResourceEmbedded();
+        String json = om.writeValueAsString(resource);
+        assertEquals(
+                "{" +
+                    "\"_links\":{" +
+                        "\"self\":{\"href\":\"/top/1\"}" +
+                    "}," +
+                    "\"_embedded\":{" +
+                        "\"child\":{\"@type\":\"ChildResource\",\"_links\":{\"self\":{\"href\":\"/top/1/child/1\"}},\"id\":\"1\"}" +
+                    "}," +
+                    "\"id\":\"1\"}", json);
+    }
 
-  @Test
-  public void testSerializationForResourceWithList() throws Exception {
+    @Test
+    public void testSerializationForResource() throws Exception {
+        @Resource
+        @SuppressWarnings("unused")
+        class SimpleTopResource {
+            public String id = "1";
+            @Link
+            public HALLink self = new HALLink.Builder(URI.create("/top/1")).build();
+            public ChildResource child = new ChildResource("1");
+        }
+        SimpleTopResource resource = new SimpleTopResource();
+        String json = om.writeValueAsString(resource);
+        assertEquals(
+                "{" +
+                    "\"_links\":{" +
+                        "\"self\":{\"href\":\"/top/1\"}" +
+                    "}," +
+                    "\"id\":\"1\"," +
+                    "\"child\":{" +
+                    "\"@type\":\"ChildResource\",\"_links\":{\"self\":{\"href\":\"/top/1/child/1\"}},\"id\":\"1\"" +
+                "}}",
+                json);
+    }
+
+    @Test
+    public void testSerializationForAnnotatedPolymorphicObject() throws Exception {
+        ChildResource resource = new ChildResource("1");
+        String json = om.writeValueAsString(resource);
+        assertEquals(
+                "{" +
+                    "\"@type\":\"ChildResource\"," +
+                    "\"_links\":{" +
+                        "\"self\":{\"href\":\"/top/1/child/1\"}" +
+                    "}," +
+                    "\"id\":\"1\"" +
+                "}", json);
+    }
+
+    @Test
+    public void testSerializationForNotAnnotatedPolymorphicObject() throws Exception {
+        ChildResource resource = new OtherChildResource("1", "Max");
+        String json = om.writeValueAsString(resource);
+        assertEquals(
+                "{" +
+                    "\"@type\":\"OtherChildResource\"," +
+                    "\"_links\":{" +
+                        "\"self\":{\"href\":\"/top/1/child/1\"}" +
+                    "}," +
+                    "\"id\":\"1\"," +
+                    "\"name\":\"Max\"" +
+                "}", json);
+    }
+
+    @JsonTypeInfo(use = Id.NAME, include = As.PROPERTY, defaultImpl = ChildResource.class)
+    @JsonSubTypes({ @JsonSubTypes.Type(value = OtherChildResource.class, name = "OtherChildResource") })
+    @JsonTypeName("ChildResource")
     @Resource
-    @SuppressWarnings("unused")
-    class TopResourceWithoutEmbedded {
-	public String id = "1";
-	@Link public HALLink self = new HALLink.Builder(URI.create("/top/1")).build();
-	 public Collection<ChildResource> children = Arrays.asList(new ChildResource("1"), new OtherChildResource("2", "Max"));
+    public static class ChildResource {
+        public String id;
+        @Link
+        public HALLink self;
+
+        public ChildResource(String id) {
+            this.id = id;
+            self = new HALLink.Builder(URI.create("/top/1/child/" + id)).build();
+        }
     }
 
-    TopResourceWithoutEmbedded resource = new TopResourceWithoutEmbedded();
-    String json = om.writeValueAsString(resource);
-    assertEquals(
-        "{"
-            + "\"_links\":{"
-            + "\"self\":{\"href\":\"/top/1\"}"
-            + "},"
-            + "\"id\":\"1\","
-            + "\"children\":["
-            + "{\"@type\":\"ChildResource\",\"_links\":{\"self\":{\"href\":\"/top/1/child/1\"}},\"id\":\"1\"},"
-            + "{\"@type\":\"OtherChildResource\",\"_links\":{\"self\":{\"href\":\"/top/1/child/2\"}},\"id\":\"2\",\"name\":\"Max\"}]"
-            + "}",
-        json);
-  }
-
-  @Test
-  public void testSerializationForResourceEmbedded() throws Exception {
     @Resource
-    @SuppressWarnings("unused")
-    class SimpleTopResourceEmbedded {
-	public String id = "1";
-	@Link
-	public HALLink self = new HALLink.Builder(URI.create("/top/1")).build();
-	@EmbeddedResource
-	public ChildResource child = new ChildResource("1");
+    @JsonTypeName("OtherChildResource")
+    public static class OtherChildResource extends ChildResource {
+        public String name;
+
+        public OtherChildResource(String id, String name) {
+            super(id);
+            this.name = name;
+        }
     }
-
-    SimpleTopResourceEmbedded resource = new SimpleTopResourceEmbedded();
-    String json = om.writeValueAsString(resource);
-    assertEquals(
-        "{"
-            + "\"_links\":{"
-            + "\"self\":{\"href\":\"/top/1\"}"
-            + "},"
-            + "\"_embedded\":{"
-            + "\"child\":{\"@type\":\"ChildResource\",\"_links\":{\"self\":{\"href\":\"/top/1/child/1\"}},\"id\":\"1\"}"
-            + "},"
-            + "\"id\":\"1\"}",
-        json);
-  }
-
-  @Test
-  public void testSerializationForResource() throws Exception {
-    @Resource
-    @SuppressWarnings("unused")
-    class SimpleTopResource {
-	public String id = "1";
-	@Link
-	public HALLink self = new HALLink.Builder(URI.create("/top/1")).build();
-	public ChildResource child = new ChildResource("1");
-    }
-
-    SimpleTopResource resource = new SimpleTopResource();
-    String json = om.writeValueAsString(resource);
-    assertEquals(
-        "{"
-            + "\"_links\":{"
-            + "\"self\":{\"href\":\"/top/1\"}"
-            + "},"
-            + "\"id\":\"1\","
-            + "\"child\":{"
-            + "\"@type\":\"ChildResource\",\"_links\":{\"self\":{\"href\":\"/top/1/child/1\"}},\"id\":\"1\""
-            + "}}",
-        json);
-  }
-
-  @Test
-  public void testSerializationForAnnotatedPolymorphicObject() throws Exception {
-    ChildResource resource = new ChildResource("1");
-    String json = om.writeValueAsString(resource);
-    assertEquals(
-        "{"
-            + "\"@type\":\"ChildResource\","
-            + "\"_links\":{"
-            + "\"self\":{\"href\":\"/top/1/child/1\"}"
-            + "},"
-            + "\"id\":\"1\"}",
-        json);
-  }
-
-  @Test
-  public void testSerializationForNotAnnotatedPolymorphicObject() throws Exception {
-    ChildResource resource = new OtherChildResource("1", "Max");
-    String json = om.writeValueAsString(resource);
-    assertEquals(
-        "{"
-            + "\"@type\":\"OtherChildResource\","
-            + "\"_links\":{"
-            + "\"self\":{\"href\":\"/top/1/child/1\"}"
-            + "},"
-            + "\"id\":\"1\","
-            + "\"name\":\"Max\"}",
-        json);
-  }
-
-  @JsonTypeInfo(
-      use = Id.NAME,
-      include = As.PROPERTY,
-      defaultImpl = ChildResource.class)
-  @JsonSubTypes({@JsonSubTypes.Type(value = OtherChildResource.class, name = "OtherChildResource")})
-  @JsonTypeName("ChildResource")
-  @Resource
-  public static class ChildResource {
-    public String id;
-
-    @Link public HALLink self;
-
-    public ChildResource(String id) {
-      this.id = id;
-      self = new HALLink.Builder(URI.create("/top/1/child/" + id)).build();
-    }
-  }
-
-  @Resource
-  @JsonTypeName("OtherChildResource")
-  public static class OtherChildResource extends ChildResource {
-
-    public String name;
-
-    public OtherChildResource(String id, String name) {
-      super(id);
-      this.name = name;
-    }
-  }
 }


### PR DESCRIPTION
As the title suggest, this is fairly straight-forward. The dependencies have been updated to their latest version and the tests have been updated to use JUnit 5. I also updated `.gitignore` with a few more rules using templates from gitignore.io. 

I ran `mvn test` to ensure that all tests still pass after the update.