### PR TITLE
Provide a HAL-specific JacksonJsonProvider

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -66,6 +66,16 @@
             <artifactId>slf4j-api</artifactId>
             <version>${org.slf4j.version}</version>
         </dependency>
+        <dependency>
+			<groupId>jakarta.inject</groupId>
+		 	<artifactId>jakarta.inject-api</artifactId>
+		 	<version>1.0.3</version>
+		</dependency>
+		<dependency>
+		 	<groupId>jakarta.ws.rs</groupId>
+		 	<artifactId>jakarta.ws.rs-api</artifactId>
+		 	<version>2.1.6</version>
+		</dependency>
 
         <dependency>
             <groupId>junit</groupId>

--- a/src/main/java/io/openapitools/jackson/dataformat/hal/JacksonHALJsonProvider.java
+++ b/src/main/java/io/openapitools/jackson/dataformat/hal/JacksonHALJsonProvider.java
@@ -1,0 +1,65 @@
+package io.openapitools.jackson.dataformat.hal;
+
+import javax.inject.Named;
+import javax.ws.rs.Consumes;
+import javax.ws.rs.Produces;
+import javax.ws.rs.core.MediaType;
+import javax.ws.rs.ext.Provider;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.jaxrs.cfg.Annotations;
+import com.fasterxml.jackson.jaxrs.json.JacksonJsonProvider;
+
+@Named
+@Provider
+@Produces(JacksonHALJsonProvider.MEDIA_TYPE_APPLICATION_HAL_JSON)
+@Consumes(JacksonHALJsonProvider.MEDIA_TYPE_APPLICATION_HAL_JSON)
+public class JacksonHALJsonProvider extends JacksonJsonProvider{
+    public static final String MEDIA_TYPE_APPLICATION_HAL_JSON = "application/hal+json";
+    public static final JacksonHALModule JACKSON_HAL_MODULE = new JacksonHALModule();
+
+    public JacksonHALJsonProvider() {
+	super();
+	modifyDefaultMapperForHALJson();
+    }
+
+    public JacksonHALJsonProvider(Annotations[] annotationsToUse) {
+	super(annotationsToUse);
+	modifyDefaultMapperForHALJson();
+    }
+
+    public JacksonHALJsonProvider(ObjectMapper mapper) {
+	super(mapper);
+	modifyConfiguredMapperForHALJson();
+    }
+
+    public JacksonHALJsonProvider(ObjectMapper mapper, Annotations[] annotationsToUse) {
+	super(mapper, annotationsToUse);
+	modifyConfiguredMapperForHALJson();
+    }
+
+    /**
+     * Always return a copy of the ObjectMapper provided by the JAX-RS provider.
+     *
+     * This is necessary since this JacksonHALJsonProvider reconfigures the mapper
+     * to specifically output the HAL+JSON format. Using a copy of the existing
+     * mapper allows the original mapper to still be used for plain JSON output.
+     */
+    @Override
+    protected ObjectMapper _locateMapperViaProvider(Class<?> type, MediaType mediaType)
+    {
+	ObjectMapper mapper = super._locateMapperViaProvider(type, mediaType);
+	if(mapper == null) {
+	    return null;
+	}
+	return mapper.copy();
+    }
+
+    private void modifyDefaultMapperForHALJson() {
+        _mapperConfig.setMapper(_mapperConfig.getDefaultMapper().registerModule(JACKSON_HAL_MODULE));
+    }
+
+    private void modifyConfiguredMapperForHALJson() {
+        _mapperConfig.setMapper(_mapperConfig.getConfiguredMapper().registerModule(JACKSON_HAL_MODULE));
+    }
+}


### PR DESCRIPTION
I extended the default JacksonJsonProvider from Jackson to provide one that is specifically for HAL-based resources. It is only used by JAX-RS when the media type is `application/hal+json`. This extended provider mainly modifies the `ObjectMapper` by registering a `JacksonHALModule` (same as a `HALMapper`).

This allows you to just register `JacksonHALJsonProvider` instead of a `JacksonJsonProvider` with `HALMapper` instance. 

A big benefit here is that you can now register both a `JacksonHALJsonProvider` and a `JacksonJsonProvider`. This allows your JAX-RS implementation to serialize/deserialize both plain JSON and HAL+JSON at runtime (determined by the provided media type).

In order for this to work correctly, if the `ObjectMapper` is configured through a JAX-RS provider, this `JacksonHALJsonProvider` will use a copy of it. This allows you to configure and provide only a single `ObjectMapper` which will be used for both plain JSON and HAL+JSON.

I verified that this works in my own JAX-RS implementation though that didn't cover all the different ways that this provider can be created. But I'm not sure if it makes sense to write unit tests for this. I've allowed edits by maintainers in the PR so you can edit this branch on my fork as needed. 
