### PR TITLE
Update broken link to spec and outdated annotation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Overview
 
 This project contains a [Jackson](https://github.com/FasterXML/jackson) extension component to support the
-[HAL JSON](https://tools.ietf.org/html/draft-kelly-json-hal) format both with respect to
+[HAL JSON](https://tools.ietf.org/html/draft-kelly-json-hal-08) format both with respect to
 serializing and deserializing.
 
 The goal is to handle HAL links and embedded objects as POJO properties with a data-binding similar to
@@ -33,7 +33,7 @@ class Model {
     @Link("rel:associated")
     HALLink relation;
 
-    @Embedded
+    @EmbeddedResource
     AssociatedModel associated;
 }
 


### PR DESCRIPTION
As reported in #35, the URL to the HAL specification was broken, and the incorrect name was used as annotation for an embedded resource. These were easy to fix so I did. 

There was also a suggestion to include an example for `@Link` on a `Collection<HALLink>` field in #35. I didn't include that here since that would require actually changing the examples, and making sure that the corresponding JSON is correct.