### PR TITLE
Update Github Actions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -7,12 +7,13 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        java: [ 8, 12, 15 ]
+        java: [ 8, 11, 12, 15 ]
     steps:
       - uses: actions/checkout@v2
-      - name: Set Java
-        uses: actions/setup-java@v1
+      - name: Setup Java
+        uses: actions/setup-java@v2
         with:
+          distribution: 'adopt'
           java-version: ${{ matrix.java }}
       - name: Cache Maven packages
         uses: actions/cache@v2


### PR DESCRIPTION
This uses the latest release of the setup-java Github Action. I've also included Java 11 in the versions on which to test since it is the latest LTS release for Java. 